### PR TITLE
updated Olympus.delete to avoid player desync

### DIFF
--- a/scripts/OlympusCommand.lua
+++ b/scripts/OlympusCommand.lua
@@ -341,8 +341,13 @@ function Olympus.delete(ID, lat, lng)
 	Olympus.debug("Olympus.delete " .. ID, 2)
 	local unit = Olympus.getUnitByID(ID)
 	if unit then
-		unit:destroy();
-		Olympus.debug("Olympus.delete completed successfully", 2)
+		if unit:getPlayerName() then
+			trigger.action.explosion(unit:getPoint() , 250 ) --consider replacing with forcibly deslotting the player, however this will work for now
+			Olympus.debug("Olympus.delete completed successfully", 2)
+		else
+			unit:destroy(); --works for AI units not players
+			Olympus.debug("Olympus.delete completed successfully", 2)
+		end
 	end
 end
 


### PR DESCRIPTION
destroy() doesnt work for players properly, and since currently we do allow delete to be run on players i think (i wouldn't suggest changing that though maybe eventually add a confirmation dialogue for players down the road) Ive added a quick check to function differently for players and AI