### PR TITLE
String management for loadout items.

### DIFF
--- a/client/public/stylesheets/unitinfopanel.css
+++ b/client/public/stylesheets/unitinfopanel.css
@@ -26,19 +26,16 @@
 }
 
 
-#loadout-container {
-	width:250px;
-}
-
 #loadout {
 	display:flex;
+	overflow: visible;
 }
 
 #loadout-silhouette {
 	align-items: center;
 	display:flex;
 	justify-content: center;
-	width:55%;
+	width:100px;
 }
 
 #loadout-silhouette::before {
@@ -58,7 +55,6 @@
 	display:flex;
 	flex-flow: column nowrap;
 	row-gap: 8px;
-	width:45%;
 }
 
 
@@ -82,9 +78,11 @@
 
 #loadout-items > *::after {
 	content: attr( data-item );
-	width:52px;
+	overflow: hidden;
+	position:relative;
+	text-overflow: ellipsis;
+	width:80px;
 }
-
 
 
 #fuel-percentage {
@@ -112,7 +110,6 @@
 	height:6px;
 	margin-top:4px;
 	overflow: hidden;
-	width:90%;
 }
 
 #fuel-display #fuel-bar {

--- a/client/views/uikit.ejs
+++ b/client/views/uikit.ejs
@@ -1136,6 +1136,37 @@
                             </div>
 
                         </div>
+
+                        <div class="example">
+
+                            <div id="unit-info-panel" class="ol-panel" style="position:relative;">
+
+                                <div class="ol-panel-board">
+                            
+                                    <div id="loadout-container" class="panel-section">
+                            
+                                        <div id="loadout">
+                                            <div id="loadout-silhouette" style="--loadout-background-image:url('/images/units/f-15.png');"></div>
+                                            <div id="loadout-items">
+                                                <div data-qty="1150" data-item="30mm AP"></div>
+                                                <div data-qty="2" data-item="AIM-9M with a really long name for no reason"></div>
+                                                <div data-qty="6" data-item="Mk-82"></div>
+                                            </div>
+                                        </div>
+                                        
+
+                                        <div id="fuel-percentage" data-percentage="45"></div>
+                                        <div id="fuel-display">
+                                            <div id="fuel-bar" class="highlight-coalition" data-coalition="blue" style="width:0%;"></div>
+                                        </div>
+                            
+                                    </div>
+                            
+                                </div>
+                            
+                            </div>
+
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
Give a bit more room for the strings and limited sizing via text-overflow:ellipsis.