### PR TITLE
Added coalition to aircraftdatabase.ts and switched era list to string

### DIFF
--- a/client/src/@types/unitdatabase.d.ts
+++ b/client/src/@types/unitdatabase.d.ts
@@ -14,7 +14,8 @@ interface LoadoutBlueprint {
 
 interface UnitBlueprint {
     name: string;
-    era: string[];
+    coalition: string;
+    era: string;
     label: string;
     shortLabel: string;
     type?: string;

--- a/client/src/units/aircraftdatabase.ts
+++ b/client/src/units/aircraftdatabase.ts
@@ -6,7 +6,8 @@ export class AircraftDatabase extends UnitDatabase {
       this.blueprints = {
          "A-10C_2": {
             "name": "A-10C_2",
-            "era": ["Late Cold War", "Modern"],
+            "coalition": "Blue",
+            "era": "Late Cold War",
             "label": "A-10C Warthog",
             "shortLabel": "10",
             "loadouts": [
@@ -108,8 +109,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "AJS37": {
             "name": "AJS37",
+            "coalition": "Blue",
             "label": "AJS37 Viggen",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "37",
             "loadouts": [
                {
@@ -190,8 +192,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "AV8BNA": {
             "name": "AV8BNA",
+            "coalition": "Blue",
             "label": "AV8BNA Harrier",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "8",
             "loadouts": [
                {
@@ -258,8 +261,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "C-101CC": {
             "name": "C-101CC",
+            "coalition": "Blue",
             "label": "C-101CC",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "101",
             "loadouts": [
                {
@@ -322,8 +326,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "H-6J": {
             "name": "H-6J",
+            "coalition": "Red",
             "label": "H-6J Badger",
-            "era": ["Mid Cold War, Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "H6",
             "loadouts": [
                {
@@ -359,8 +364,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "J-11A": {
             "name": "J-11A",
+            "coalition": "Red",
             "label": "J-11A Flaming Dragon",
-            "era": ["Modern"],
+            "era": "Modern",
             "shortLabel": "11",
             "loadouts": [
                {
@@ -433,8 +439,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "JF-17": {
             "name": "JF-17",
+            "coalition": "Red",
             "label": "JF-17 Thunder",
-            "era": ["Modern"],
+            "era": "Modern",
             "shortLabel": "17",
             "loadouts": [
                {
@@ -527,8 +534,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-16C_50": {
             "name": "F-16C_50",
+            "coalition": "Blue",
             "label": "F-16C Viper",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "16",
             "loadouts": [
                {
@@ -637,8 +645,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-5E-3": {
             "name": "F-5E-3",
+            "coalition": "Blue",
             "label": "F-5E Tiger",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "5",
             "loadouts": [
                {
@@ -697,8 +706,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-86F Sabre": {
             "name": "F-86F Sabre",
+            "coalition": "Blue",
             "label": "F-86F Sabre",
-            "era": ["Early Cold War, Mid Cold War"],
+            "era": "Early Cold War",
             "shortLabel": "86",
             "loadouts": [
                {
@@ -759,8 +769,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-14A-135-GR": {
             "name": "F-14A-135-GR",
+            "coalition": "Blue",
             "label": "F-14A-135-GR Tomcat",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "14A",
             "loadouts": [
                {
@@ -857,8 +868,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-14B": {
             "name": "F-14B",
+            "coalition": "Blue",
             "label": "F-14B Tomcat",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "14B",
             "loadouts": [
                {
@@ -955,7 +967,8 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "FA-18C_hornet": {
             "name": "FA-18C_hornet",
-            "era": ["Late Cold War", "Modern"],
+            "coalition": "Blue",
+            "era": "Late Cold War",
             "label": "F/A-18C",
             "shortLabel": "18",
             "loadouts": [
@@ -1101,8 +1114,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "I-16": {
             "name": "I-16",
+            "coalition": "",
             "label": "I-16",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "I16",
             "loadouts": [
                {
@@ -1121,8 +1135,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "L-39ZA": {
             "name": "L-39ZA",
+            "coalition": "Red",
             "label": "L-39ZA",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "39",
             "loadouts": [
                {
@@ -1183,8 +1198,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "M-2000C": {
             "name": "M-2000C",
+            "coalition": "Blue",
             "label": "M-2000C Mirage",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "M2KC",
             "loadouts": [
                {
@@ -1273,8 +1289,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MB-339A": {
             "name": "MB-339A",
+            "coalition": "Blue",
             "label": "MB-339A",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "339A",
             "loadouts": [
                {
@@ -1341,8 +1358,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-19P": {
             "name": "MiG-19P",
+            "coalition": "Red",
             "label": "MiG-19 Farmer",
-            "era": ["Early Cold War", "Mid Cold War"],
+            "era": "Early Cold War",
             "shortLabel": "19",
             "loadouts": [
                {
@@ -1411,8 +1429,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-21Bis": {
             "name": "MiG-21Bis",
+            "coalition": "Red",
             "label": "MiG-21 Fishbed",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "21",
             "loadouts": [
                {
@@ -1531,8 +1550,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Mirage-F1EE": {
             "name": "Mirage-F1EE",
+            "coalition": "Blue",
             "label": "Mirage-F1EE",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "F1EE",
             "loadouts": [
                {
@@ -1591,8 +1611,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "A-20G": {
             "name": "A-20G",
+            "coalition": "",
             "label": "A-20G Havoc",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "A20",
             "loadouts": [
                {
@@ -1629,8 +1650,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Bf-109K-4": {
             "name": "Bf-109K-4",
+            "coalition": "",
             "label": "Bf-109K-4 Fritz",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "109",
             "loadouts": [
                {
@@ -1678,8 +1700,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "FW-190A8": {
             "name": "FW-190A8",
+            "coalition": "",
             "label": "FW-190A8 Bosch",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "190A8",
             "loadouts": [
                {
@@ -1727,8 +1750,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "FW-190D9": {
             "name": "FW-190D9",
+            "coalition": "",
             "label": "FW-190D9 Jerry",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "190D9",
             "loadouts": [
                {
@@ -1776,8 +1800,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MosquitoFBMkVI": {
             "name": "MosquitoFBMkVI",
+            "coalition": "",
             "label": "Mosquito FB MkVI",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "Mosquito",
             "loadouts": [
                {
@@ -1829,8 +1854,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "P-47D-40": {
             "name": "P-47D-40",
+            "coalition": "",
             "label": "P-47D Thunderbolt",
-            "era": ["WW2"],
+            "era": "WW2",
             "shortLabel": "P47",
             "loadouts": [
                {
@@ -1870,8 +1896,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "P-51D-30-NA": {
             "name": "P-51D-30-NA",
+            "coalition": "",
             "label": "P-51D Mustang",
-            "era": ["WW2", "Early Cold War"],
+            "era": "WW2",
             "shortLabel": "P51",
             "loadouts": [
                {
@@ -1911,8 +1938,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "A-50": {
             "name": "A-50",
+            "coalition": "Red",
             "label": "A-50 Mainstay",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "A50",
             "loadouts": [
                {
@@ -1942,8 +1970,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "An-26B": {
             "name": "An-26B",
+            "coalition": "Red",
             "label": "An-26B Curl",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "26",
             "loadouts": [
                {
@@ -1962,8 +1991,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "An-30M": {
             "name": "An-30M",
+            "coalition": "Red",
             "label": "An-30M Clank",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "30",
             "loadouts": [
                {
@@ -1982,8 +2012,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "B-1B": {
             "name": "B-1B",
+            "coalition": "Blue",
             "label": "B-1B Lancer",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "1",
             "loadouts": [
                {
@@ -2016,8 +2047,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "B-52H": {
             "name": "B-52H",
+            "coalition": "Blue",
             "label": "B-52H Stratofortress",
-            "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Early Cold War",
             "shortLabel": "52",
             "loadouts": [
                {
@@ -2050,8 +2082,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "C-130": {
             "name": "C-130",
+            "coalition": "Blue",
             "label": "C-130 Hercules",
-            "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Early Cold War",
             "shortLabel": "130",
             "loadouts": [
                {
@@ -2070,8 +2103,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "C-17A": {
             "name": "C-17A",
+            "coalition": "Blue",
             "label": "C-17A Globemaster",
-            "era": ["Modern"],
+            "era": "Modern",
             "shortLabel": "C17",
             "loadouts": [
                {
@@ -2090,8 +2124,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "E-3A": {
             "name": "E-3A",
+            "coalition": "Blue",
             "label": "E-3A Sentry",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "E3",
             "loadouts": [
                {
@@ -2110,8 +2145,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "E-2C": {
             "name": "E-2C",
+            "coalition": "Blue",
             "label": "E-2C Hawkeye",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "2C",
             "loadouts": [
                {
@@ -2130,8 +2166,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-117A": {
             "name": "F-117A",
+            "coalition": "Blue",
             "label": "F-117A Nighthawk",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "117",
             "loadouts": [
                {
@@ -2164,8 +2201,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-15C": {
             "name": "F-15C",
+            "coalition": "Blue",
             "label": "F-15C Eagle",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "15",
             "loadouts": [
                {
@@ -2228,8 +2266,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-15E": {
             "name": "F-15E",
+            "coalition": "Blue",
             "label": "F-15E Strike Eagle",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "15",
             "loadouts": [
                {
@@ -2308,8 +2347,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "F-4E": {
             "name": "F-4E",
+            "coalition": "Blue",
             "label": "F-4E Phantom II",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "4",
             "loadouts": [
                {
@@ -2398,8 +2438,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "IL-76MD": {
             "name": "IL-76MD",
+            "coalition": "Red",
             "label": "IL-76MD Candid",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "76",
             "loadouts": [
                {
@@ -2418,8 +2459,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "IL-78M": {
             "name": "IL-78M",
+            "coalition": "Red",
             "label": "IL-78M Midas",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "78",
             "loadouts": [
                {
@@ -2438,8 +2480,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "KC-135": {
             "name": "KC-135",
+            "coalition": "Blue",
             "label": "KC-135 Stratotanker",
-            "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Early Cold War",
             "shortLabel": "135",
             "loadouts": [
                {
@@ -2458,8 +2501,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "KC135MPRS": {
             "name": "KC135MPRS",
+            "coalition": "Blue",
             "label": "KC-135 MPRS Stratotanker",
-            "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Early Cold War",
             "shortLabel": "135M",
             "loadouts": [
                {
@@ -2478,8 +2522,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "S-3B Tanker": {
             "name": "S-3B Tanker",
+            "coalition": "Blue",
             "label": "S-3B Tanker",
-            "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Early Cold War",
             "shortLabel": "S3B",
             "loadouts": [
                {
@@ -2498,8 +2543,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-15bis": {
             "name": "MiG-15bis",
+            "coalition": "Red",
             "label": "MiG-15 Fagot",
-            "era": ["Early Cold War", "Mid Cold War"],
+            "era": "Early Cold War",
             "shortLabel": "M15",
             "loadouts": [
                {
@@ -2546,8 +2592,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-23MLD": {
             "name": "MiG-23MLD",
+            "coalition": "Red",
             "label": "MiG-23 Flogger",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "23",
             "loadouts": [
                {
@@ -2610,8 +2657,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-25RBT": {
             "name": "MiG-25RBT",
+            "coalition": "Red",
             "label": "MiG-25RBT Foxbat",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "25",
             "loadouts": [
                {
@@ -2662,8 +2710,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-25PD": {
             "name": "MiG-25PD",
+            "coalition": "Red",
             "label": "MiG-25PD Foxbat",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "25",
             "loadouts": [
                {
@@ -2700,8 +2749,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-27K": {
             "name": "MiG-27K",
+            "coalition": "Red",
             "label": "MiG-27K Flogger-D",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "27",
             "loadouts": [
                {
@@ -2770,8 +2820,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-29A": {
             "name": "MiG-29A",
+            "coalition": "Red",
             "label": "MiG-29A Fulcrum",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "29A",
             "loadouts": [
                {
@@ -2856,8 +2907,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-29S": {
             "name": "MiG-29S",
+            "coalition": "Red",
             "label": "MiG-29S Fulcrum",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "29",
             "loadouts": [
                {
@@ -2964,8 +3016,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MiG-31": {
             "name": "MiG-31",
+            "coalition": "Red",
             "label": "MiG-31 Foxhound",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "31",
             "loadouts": [
                {
@@ -3002,8 +3055,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "MQ-9 Reaper": {
             "name": "MQ-9 Reaper",
+            "coalition": "Blue",
             "label": "MQ-9 Reaper",
-            "era": ["Modern"],
+            "era": "Modern",
             "shortLabel": "9",
             "loadouts": [
                {
@@ -3036,8 +3090,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-17M4": {
             "name": "Su-17M4",
+            "coalition": "Red",
             "label": "Su-17M4 Fitter",
-            "era": ["Mid Cold War", "Late Cold War"],
+            "era": "Mid Cold War",
             "shortLabel": "17M4",
             "loadouts": [
                {
@@ -3078,8 +3133,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-24M": {
             "name": "Su-24M",
+            "coalition": "Red",
             "label": "Su-24M Fencer",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "24",
             "loadouts": [
                {
@@ -3116,8 +3172,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-25": {
             "name": "Su-25",
+            "coalition": "Red",
             "label": "Su-25A Frogfoot",
-            "era": ["Late Cold War"],
+            "era": "Late Cold War",
             "shortLabel": "S25",
             "loadouts": [
                {
@@ -3188,8 +3245,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-25T": {
             "name": "Su-25",
+            "coalition": "Red",
             "label": "Su-25T Frogfoot",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "S25T",
             "loadouts": [
                {
@@ -3294,8 +3352,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-27": {
             "name": "Su-27",
+            "coalition": "Red",
             "label": "Su-27 Flanker",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "27",
             "loadouts": [
                {
@@ -3394,8 +3453,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-30": {
             "name": "Su-30",
+            "coalition": "Red",
             "label": "Su-30 Super Flanker",
-            "era": ["Modern"],
+            "era": "Late Cold War",
             "shortLabel": "30",
             "loadouts": [
                {
@@ -3484,8 +3544,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-33": {
             "name": "Su-33",
+            "coalition": "Red",
             "label": "Su-33 Navy Flanker",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "33",
             "loadouts": [
                {
@@ -3574,8 +3635,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Su-34": {
             "name": "Su-34",
+            "coalition": "Red",
             "label": "Su-34 Hellduck",
-            "era": ["Modern"],
+            "era": "Modern",
             "shortLabel": "34",
             "loadouts": [
                {
@@ -3620,8 +3682,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tornado IDS": {
             "name": "Tornado IDS",
+            "coalition": "Blue",
             "label": "Tornado IDS",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "IDS",
             "loadouts": [
                {
@@ -3662,8 +3725,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tornado GR4": {
             "name": "Tornado GR4",
+            "coalition": "Blue",
             "label": "Tornado GR4",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "GR4",
             "loadouts": [
                {
@@ -3756,8 +3820,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tu-142": {
             "name": "Tu-142",
+            "coalition": "Red",
             "label": "Tu-142 Bear",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "142",
             "loadouts": [
                {
@@ -3790,8 +3855,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tu-160": {
             "name": "Tu-160",
+            "coalition": "Red",
             "label": "Tu-160 Blackjack",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "160",
             "loadouts": [
                {
@@ -3824,8 +3890,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tu-22M3": {
             "name": "Tu-22M3",
+            "coalition": "Red",
             "label": "Tu-22M3 Backfire",
-            "era": ["Late Cold War", "Modern"],
+            "era": "Late Cold War",
             "shortLabel": "T22",
             "loadouts": [
                {
@@ -3872,8 +3939,9 @@ export class AircraftDatabase extends UnitDatabase {
          },
          "Tu-95MS": {
             "name": "Tu-95MS",
+            "coalition": "Red",
             "label": "Tu-95MS Bear",
-            "era": ["Mid Cold War", "Late Cold War", "Modern"],
+            "era": "Mid Cold War",
             "shortLabel": "95",
             "loadouts": [
                {

--- a/client/src/units/aircraftdatabase.ts
+++ b/client/src/units/aircraftdatabase.ts
@@ -1,3979 +1,3979 @@
 import { UnitDatabase } from "./unitdatabase"
 
 export class AircraftDatabase extends UnitDatabase {
-   constructor() {
-      super();
-      this.blueprints = {
-         "A-10C_2": {
-            "name": "A-10C_2",
-            "coalition": "Blue",
-            "era": "Late Cold War",
-            "label": "A-10C Warthog",
-            "shortLabel": "10",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Mk-84",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk-82",
-                        "quantity": 6
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "Mk-82*6,Mk-84*2,AIM-9*2,ECM",
-                  "name": "Heavy / Mk-84 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-65D",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "CBU-97",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "TGP",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AGM-65D*4, CBU-97*4,TGP, ECM, AIM-9*2",
-                  "name": "Heavy / AGM-65D / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "GBU-12",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "GBU-10",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "TGP",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "GBU-12*6,GBU-10*2,TGP, AIM-9*2",
-                  "name": "Heavy / GBU-12 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+    constructor() {
+        super();
+        this.blueprints = {
+            "A-10C_2": {
+                "name": "A-10C_2",
+                "coalition": "Blue",
+                "era": "Late Cold War",
+                "label": "A-10C Warthog",
+                "shortLabel": "10",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Mk-84",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk-82",
+                                "quantity": 6
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "Mk-82*6,Mk-84*2,AIM-9*2,ECM",
+                        "name": "Heavy / Mk-84 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-65D",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "CBU-97",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "TGP",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AGM-65D*4, CBU-97*4,TGP, ECM, AIM-9*2",
+                        "name": "Heavy / AGM-65D / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "GBU-12",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "GBU-10",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "TGP",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "GBU-12*6,GBU-10*2,TGP, AIM-9*2",
+                        "name": "Heavy / GBU-12 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "a-10.png"
-         },
-         "AJS37": {
-            "name": "AJS37",
-            "coalition": "Blue",
-            "label": "AJS37 Viggen",
-            "era": "Mid Cold War",
-            "shortLabel": "37",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "BK90",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "RB-74",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "XT",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Strike: BK90 (MJ1)*2, RB-74*2, XT",
-                  "name": "Heavy / BK90 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "ARAK M70 HE",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "XT",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "CAS: ARAK M70 HE*4, XT",
-                  "name": "Heavy / ARAK M79 HE / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "RB05",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "RB74",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "XT",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "Anti-ship (RB05): RB-05A*2, RB-74*2, XT",
-                  "name": "Heavy / RB05 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "a-10.png"
+            },
+            "AJS37": {
+                "name": "AJS37",
+                "coalition": "Blue",
+                "label": "AJS37 Viggen",
+                "era": "Mid Cold War",
+                "shortLabel": "37",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "BK90",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "RB-74",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "XT",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Strike: BK90 (MJ1)*2, RB-74*2, XT",
+                        "name": "Heavy / BK90 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "ARAK M70 HE",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "XT",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "CAS: ARAK M70 HE*4, XT",
+                        "name": "Heavy / ARAK M79 HE / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "RB05",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "RB74",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "XT",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "Anti-ship (RB05): RB-05A*2, RB-74*2, XT",
+                        "name": "Heavy / RB05 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "viggen.png"
-         },
-         "AV8BNA": {
-            "name": "AV8BNA",
-            "coalition": "Blue",
-            "label": "AV8BNA Harrier",
-            "era": "Late Cold War",
-            "shortLabel": "8",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "GBU-38",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AGM-122 Sidearm",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "Fuel 300",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "H-M-H 3",
-                  "name": "Heavy / GBU-38 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-65F",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GAU-12",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "Anti Armor",
-                  "name": "Heavy / AGM-65F / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "viggen.png"
+            },
+            "AV8BNA": {
+                "name": "AV8BNA",
+                "coalition": "Blue",
+                "label": "AV8BNA Harrier",
+                "era": "Late Cold War",
+                "shortLabel": "8",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "GBU-38",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AGM-122 Sidearm",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "Fuel 300",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "H-M-H 3",
+                        "name": "Heavy / GBU-38 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-65F",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GAU-12",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "Anti Armor",
+                        "name": "Heavy / AGM-65F / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "av8bna.png"
-         },
-         "C-101CC": {
-            "name": "C-101CC",
-            "coalition": "Blue",
-            "label": "C-101CC",
-            "era": "Late Cold War",
-            "shortLabel": "101",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "DEFA 553 CANNON (I)",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "2*AIM-9M, DEFA 553 CANNON (I)",
-                  "name": "Light / Fox 2 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "BELOUGA",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "BIN-200",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AN-M3 CANNON",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "2*AIM-9M ,2*BELOUGA,2*BIN-200, AN-M3 CANNON",
-                  "name": "Heavy / BELOUGA, BIN-200 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "av8bna.png"
+            },
+            "C-101CC": {
+                "name": "C-101CC",
+                "coalition": "Blue",
+                "label": "C-101CC",
+                "era": "Late Cold War",
+                "shortLabel": "101",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "DEFA 553 CANNON (I)",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "2*AIM-9M, DEFA 553 CANNON (I)",
+                        "name": "Light / Fox 2 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "BELOUGA",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "BIN-200",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AN-M3 CANNON",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "2*AIM-9M ,2*BELOUGA,2*BIN-200, AN-M3 CANNON",
+                        "name": "Heavy / BELOUGA, BIN-200 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "c-101.png"
-         },
-         "H-6J": {
-            "name": "H-6J",
-            "coalition": "Red",
-            "label": "H-6J Badger",
-            "era": "Mid Cold War",
-            "shortLabel": "H6",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "250-3 LD Bomb",
-                        "quantity": 36
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "250-3 LD Bomb x 36",
-                  "name": "Heavy / Bombs / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "KD-20",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "KD-20 x 4",
-                  "name": "Heavy / KD-20 / Long Range"
-               }
-            ],
-            "filename": "h-6.png"
-         },
-         "J-11A": {
-            "name": "J-11A",
-            "coalition": "Red",
-            "label": "J-11A Flaming Dragon",
-            "era": "Modern",
-            "shortLabel": "11",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-500",
-                        "quantity": 8
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500x8,R-73x2,ECM",
-                  "name": "Heavy / Fox 2 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-77",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-77x2, R-73x2",
-                  "name": "Light / Fox 3 / Long Range"
-               },
-                              {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-27ERx2, R-73x2",
-                  "name": "Light / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "c-101.png"
+            },
+            "H-6J": {
+                "name": "H-6J",
+                "coalition": "Red",
+                "label": "H-6J Badger",
+                "era": "Mid Cold War",
+                "shortLabel": "H6",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "250-3 LD Bomb",
+                                "quantity": 36
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "250-3 LD Bomb x 36",
+                        "name": "Heavy / Bombs / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "KD-20",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "KD-20 x 4",
+                        "name": "Heavy / KD-20 / Long Range"
+                    }
+                ],
+                "filename": "h-6.png"
+            },
+            "J-11A": {
+                "name": "J-11A",
+                "coalition": "Red",
+                "label": "J-11A Flaming Dragon",
+                "era": "Modern",
+                "shortLabel": "11",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-500",
+                                "quantity": 8
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500x8,R-73x2,ECM",
+                        "name": "Heavy / Fox 2 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-77",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-77x2, R-73x2",
+                        "name": "Light / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-27ERx2, R-73x2",
+                        "name": "Light / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-27.png"
-         },
-         "JF-17": {
-            "name": "JF-17",
-            "coalition": "Red",
-            "label": "JF-17 Thunder",
-            "era": "Modern",
-            "shortLabel": "17",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "PL-5E2",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "C802AK",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "800L Tank",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "PL-5Ex2, C802AKx2, 800L Tank",
-                  "name": "Heavy / C802AK ASM / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "PL-5E2",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-12",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "800L Tank",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "WMD7",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "PL-5Ex2, 2*GBU-12x2, 800L Tank, WMD7",
-                  "name": "Heavy / C802AK ASM / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "PL-5E2",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SD-10",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "1100L Tank",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "WMD7",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "PL-5Ex2, SD-10x2, 1100L Tankx2, WMD7",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-27.png"
+            },
+            "JF-17": {
+                "name": "JF-17",
+                "coalition": "Red",
+                "label": "JF-17 Thunder",
+                "era": "Modern",
+                "shortLabel": "17",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "PL-5E2",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "C802AK",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "800L Tank",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "PL-5Ex2, C802AKx2, 800L Tank",
+                        "name": "Heavy / C802AK ASM / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "PL-5E2",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-12",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "800L Tank",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "WMD7",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "PL-5Ex2, 2*GBU-12x2, 800L Tank, WMD7",
+                        "name": "Heavy / C802AK ASM / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "PL-5E2",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SD-10",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "1100L Tank",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "WMD7",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "PL-5Ex2, SD-10x2, 1100L Tankx2, WMD7",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "jf-17.png"
-         },
-         "F-16C_50": {
-            "name": "F-16C_50",
-            "coalition": "Blue",
-            "label": "F-16C Viper",
-            "era": "Late Cold War",
-            "shortLabel": "16",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-120C",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-120C*2, AIM-9X*4, FUEL*2",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-120C",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "TGP",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AGM-65D",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AIM-120C*2, AIM-9X*2, AGM-65D*4, FUEL*2, ECM, TGP",
-                  "name": "Heavy / Fox 3, AGM-65D / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-120C",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "TGP",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "GBU-10",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AIM-120C*2, AIM-9X*2, GBU-10*2, FUEL*2, ECM, TGP",
-                  "name": "Heavy / Fox 3, GBU-10 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "jf-17.png"
+            },
+            "F-16C_50": {
+                "name": "F-16C_50",
+                "coalition": "Blue",
+                "label": "F-16C Viper",
+                "era": "Late Cold War",
+                "shortLabel": "16",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-120C",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-120C*2, AIM-9X*4, FUEL*2",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-120C",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "TGP",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AGM-65D",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AIM-120C*2, AIM-9X*2, AGM-65D*4, FUEL*2, ECM, TGP",
+                        "name": "Heavy / Fox 3, AGM-65D / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-120C",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "TGP",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "GBU-10",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AIM-120C*2, AIM-9X*2, GBU-10*2, FUEL*2, ECM, TGP",
+                        "name": "Heavy / Fox 3, GBU-10 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-16c.png"
-         },
-         "F-5E-3": {
-            "name": "F-5E-3",
-            "coalition": "Blue",
-            "label": "F-5E Tiger",
-            "era": "Mid Cold War",
-            "shortLabel": "5",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Fuel 275",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-9P5",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9P5*2, Fuel 275*3",
-                  "name": "Heavy / Fox 2 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Mk-82",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9P5",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel 275",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Mk-82LD*4,AIM-9P*2,Fuel 275",
-                  "name": "Heavy / Fox 2 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-16c.png"
+            },
+            "F-5E-3": {
+                "name": "F-5E-3",
+                "coalition": "Blue",
+                "label": "F-5E Tiger",
+                "era": "Mid Cold War",
+                "shortLabel": "5",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Fuel 275",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-9P5",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9P5*2, Fuel 275*3",
+                        "name": "Heavy / Fox 2 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Mk-82",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9P5",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel 275",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Mk-82LD*4,AIM-9P*2,Fuel 275",
+                        "name": "Heavy / Fox 2 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-5.png"
-         },
-         "F-86F Sabre": {
-            "name": "F-86F Sabre",
-            "coalition": "Blue",
-            "label": "F-86F Sabre",
-            "era": "Early Cold War",
-            "shortLabel": "86",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "120gal Fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "120gal Fuel*2",
-                  "name": "Light / Guns / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "HVAR",
-                        "quantity": 16
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "HVAR*16",
-                  "name": "Light / HVAR / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AN-M64",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AN-M64*2",
-                  "name": "Light / AN-M64 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-5.png"
+            },
+            "F-86F Sabre": {
+                "name": "F-86F Sabre",
+                "coalition": "Blue",
+                "label": "F-86F Sabre",
+                "era": "Early Cold War",
+                "shortLabel": "86",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "120gal Fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "120gal Fuel*2",
+                        "name": "Light / Guns / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "HVAR",
+                                "quantity": 16
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "HVAR*16",
+                        "name": "Light / HVAR / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AN-M64",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AN-M64*2",
+                        "name": "Light / AN-M64 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short Range"
-               }
-            ],
-            "filename": "f-5.png"
-         },
-         "F-14A-135-GR": {
-            "name": "F-14A-135-GR",
-            "coalition": "Blue",
-            "label": "F-14A-135-GR Tomcat",
-            "era": "Mid Cold War",
-            "shortLabel": "14A",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-54A",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7F",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9L",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-54A-MK47*2, AIM-7F*1, AIM-9L*4, XT*2",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7F",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9L",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-7F*4, AIM-9L*4, XT*2",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-12",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "LANTIRN",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AIM-7M*1, AIM-9M*2, XT*2, GBU-12*2, LANTIRN",
-                  "name": "Heavy / Fox 3, GBU-12 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short Range"
+                    }
+                ],
+                "filename": "f-5.png"
+            },
+            "F-14A-135-GR": {
+                "name": "F-14A-135-GR",
+                "coalition": "Blue",
+                "label": "F-14A-135-GR Tomcat",
+                "era": "Mid Cold War",
+                "shortLabel": "14A",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-54A",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7F",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9L",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-54A-MK47*2, AIM-7F*1, AIM-9L*4, XT*2",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7F",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9L",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-7F*4, AIM-9L*4, XT*2",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-12",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "LANTIRN",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AIM-7M*1, AIM-9M*2, XT*2, GBU-12*2, LANTIRN",
+                        "name": "Heavy / Fox 3, GBU-12 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-14.png"
-         },
-         "F-14B": {
-            "name": "F-14B",
-            "coalition": "Blue",
-            "label": "F-14B Tomcat",
-            "era": "Late Cold War",
-            "shortLabel": "14B",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-54C",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-54C-MK47*2, AIM-7M*3, AIM-9M*2, XT*2",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-7M*6, AIM-9M*2, XT*2",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-12",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "LANTIRN",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AIM-7M*1, AIM-9M*2, XT*2, GBU-12*2, LANTIRN",
-                  "name": "Heavy / Fox 3, GBU-12 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-14.png"
+            },
+            "F-14B": {
+                "name": "F-14B",
+                "coalition": "Blue",
+                "label": "F-14B Tomcat",
+                "era": "Late Cold War",
+                "shortLabel": "14B",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-54C",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-54C-MK47*2, AIM-7M*3, AIM-9M*2, XT*2",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-7M*6, AIM-9M*2, XT*2",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-12",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "LANTIRN",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AIM-7M*1, AIM-9M*2, XT*2, GBU-12*2, LANTIRN",
+                        "name": "Heavy / Fox 3, GBU-12 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-14.png"
-         },
-         "FA-18C_hornet": {
-            "name": "FA-18C_hornet",
-            "coalition": "Blue",
-            "era": "Late Cold War",
-            "label": "F/A-18C",
-            "shortLabel": "18",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-120C-5",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9X*2, AIM-120C-5*6, FUEL*3",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9M*2, AIM-7M*4, FUEL*3",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-120C-5",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AGM-88C",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "SEAD"
-                  ],
-                  "code": "AIM-9X*2, AIM-120C-5*2, AGM-88C*2, FUEL",
-                  "name": "Heavy / Fox 3, AGM-88C / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-120C-5",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AGM-84D",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "AIM-9M*2, AIM-120C-5*1, AGM-84D*4, ATFLIR, FUEL",
-                  "name": "Heavy / Fox 3, AGM-84D / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-120C-5",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-9X",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-12",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "GBU-38",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AIM-9X*2, AIM-120C-5*1, GBU-38*4, GBU-12*4, ATFLIR, FUEL",
-                  "name": "Heavy / Fox 3, GBU-12, GBU-38 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-14.png"
+            },
+            "FA-18C_hornet": {
+                "name": "FA-18C_hornet",
+                "coalition": "Blue",
+                "era": "Late Cold War",
+                "label": "F/A-18C",
+                "shortLabel": "18",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-120C-5",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9X*2, AIM-120C-5*6, FUEL*3",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9M*2, AIM-7M*4, FUEL*3",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-120C-5",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AGM-88C",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "SEAD"
+                        ],
+                        "code": "AIM-9X*2, AIM-120C-5*2, AGM-88C*2, FUEL",
+                        "name": "Heavy / Fox 3, AGM-88C / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-120C-5",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AGM-84D",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "AIM-9M*2, AIM-120C-5*1, AGM-84D*4, ATFLIR, FUEL",
+                        "name": "Heavy / Fox 3, AGM-84D / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-120C-5",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-9X",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-12",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "GBU-38",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AIM-9X*2, AIM-120C-5*1, GBU-38*4, GBU-12*4, ATFLIR, FUEL",
+                        "name": "Heavy / Fox 3, GBU-12, GBU-38 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "fa-18c.png"
-         },
-         "I-16": {
-            "name": "I-16",
-            "coalition": "",
-            "label": "I-16",
-            "era": "WW2",
-            "shortLabel": "I16",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "fa-18c.png"
+            },
+            "I-16": {
+                "name": "I-16",
+                "coalition": "",
+                "label": "I-16",
+                "era": "WW2",
+                "shortLabel": "I16",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "i-16.png"
-         },
-         "L-39ZA": {
-            "name": "L-39ZA",
-            "coalition": "Red",
-            "label": "L-39ZA",
-            "era": "Mid Cold War",
-            "shortLabel": "39",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "S-5KO",
-                        "quantity": 32
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "S-5KOx32",
-                  "name": "Heavy / S-5KO / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-100",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-100x4",
-                  "name": "Heavy / FAB-100 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-60Mx2",
-                  "name": "Light / Fox 2 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "i-16.png"
+            },
+            "L-39ZA": {
+                "name": "L-39ZA",
+                "coalition": "Red",
+                "label": "L-39ZA",
+                "era": "Mid Cold War",
+                "shortLabel": "39",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "S-5KO",
+                                "quantity": 32
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "S-5KOx32",
+                        "name": "Heavy / S-5KO / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-100",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-100x4",
+                        "name": "Heavy / FAB-100 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-60Mx2",
+                        "name": "Light / Fox 2 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "l-39.png"
-         },
-         "M-2000C": {
-            "name": "M-2000C",
-            "coalition": "Blue",
-            "label": "M-2000C Mirage",
-            "era": "Late Cold War",
-            "shortLabel": "M2KC",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Matra Magic II",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Super 530D",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Eclair",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "Fox / S530D / Magic / Eclair",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Matra Magic II",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk82",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Kilo / 4xMk-82 / Magic",
-                  "name": "Heavy / Mk 82 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Matra Magic II",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "BAP-100",
-                        "quantity": 18
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Runway Strike"
-                  ],
-                  "code": "Bravo / BAP-100 / Magic",
-                  "name": "Heavy / BAP-100 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "l-39.png"
+            },
+            "M-2000C": {
+                "name": "M-2000C",
+                "coalition": "Blue",
+                "label": "M-2000C Mirage",
+                "era": "Late Cold War",
+                "shortLabel": "M2KC",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Matra Magic II",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Super 530D",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Eclair",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "Fox / S530D / Magic / Eclair",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Matra Magic II",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk82",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Kilo / 4xMk-82 / Magic",
+                        "name": "Heavy / Mk 82 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Matra Magic II",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "BAP-100",
+                                "quantity": 18
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Runway Strike"
+                        ],
+                        "code": "Bravo / BAP-100 / Magic",
+                        "name": "Heavy / BAP-100 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "m2000.png"
-         },
-         "MB-339A": {
-            "name": "MB-339A",
-            "coalition": "Blue",
-            "label": "MB-339A",
-            "era": "Mid Cold War",
-            "shortLabel": "339A",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "320L TipTanks",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "DEFA 553 GunPods",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk83",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk81",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "A - 2*320L TipTanks + 2*DEFA-553 GunPods + 2*Mk.83 + 2*Mk.81 ",
-                  "name": "Heavy / Mk81, Mk83 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "320L TipTanks",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "DEFA GunPods",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "LAU-10(Zuni Rockets)",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AA - 2*320L TipTanks + 2*DEFA-553 GunPods + 2*LAU-10(Zuni Rockets) [ARMADA]",
-                  "name": "Heavy / Mk 82 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "m2000.png"
+            },
+            "MB-339A": {
+                "name": "MB-339A",
+                "coalition": "Blue",
+                "label": "MB-339A",
+                "era": "Mid Cold War",
+                "shortLabel": "339A",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "320L TipTanks",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "DEFA 553 GunPods",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk83",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk81",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "A - 2*320L TipTanks + 2*DEFA-553 GunPods + 2*Mk.83 + 2*Mk.81 ",
+                        "name": "Heavy / Mk81, Mk83 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "320L TipTanks",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "DEFA GunPods",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "LAU-10(Zuni Rockets)",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AA - 2*320L TipTanks + 2*DEFA-553 GunPods + 2*LAU-10(Zuni Rockets) [ARMADA]",
+                        "name": "Heavy / Mk 82 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "c-101.png"
-         },
-         "MiG-19P": {
-            "name": "MiG-19P",
-            "coalition": "Red",
-            "label": "MiG-19 Farmer",
-            "era": "Early Cold War",
-            "shortLabel": "19",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "K-13A Atoll",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "K-13A x 2",
-                  "name": "Light / Fox-2 / Short range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "K-13A Atoll",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "167 gal tanks",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "K-13A x 2, PTB-760 x 2",
-                  "name": "Medium / Fox-2 / Medium range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-250",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ORO-57K",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-250 x 2, ORO-57K x 2",
-                  "name": "Medium / FAB250, ORO57K / Short range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "c-101.png"
+            },
+            "MiG-19P": {
+                "name": "MiG-19P",
+                "coalition": "Red",
+                "label": "MiG-19 Farmer",
+                "era": "Early Cold War",
+                "shortLabel": "19",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "K-13A Atoll",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "K-13A x 2",
+                        "name": "Light / Fox-2 / Short range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "K-13A Atoll",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "167 gal tanks",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "K-13A x 2, PTB-760 x 2",
+                        "name": "Medium / Fox-2 / Medium range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-250",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ORO-57K",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-250 x 2, ORO-57K x 2",
+                        "name": "Medium / FAB250, ORO57K / Short range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short range"
-               }
-            ],
-            "filename": "mig-19.png"
-         },
-         "MiG-21Bis": {
-            "name": "MiG-21Bis",
-            "coalition": "Red",
-            "label": "MiG-21 Fishbed",
-            "era": "Mid Cold War",
-            "shortLabel": "21",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-3 Atoll",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60 Aphid",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "130 gal tanks",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "ASO-2 Countermeasures",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "Patrol, short range",
-                  "name": "Light / Fox-2 / Short range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-3 Atoll",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60 Aphid",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "210 gal tanks",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "ASO-2 Countermeasures",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "Patrol, medium range",
-                  "name": "Medium / Fox-2 / Medium range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-3R Atoll",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "210 gal tanks",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "ASO-2 Countermeasures",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "Patrol, R-3R Only",
-                  "name": "Medium / Fox-1 / Medium range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "GROM",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-250",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "210 gal tanks",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "ASO-2 Countermeasures",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Few big targets, GROM + BOMBS",
-                  "name": "Heavy / GROM, FAB250 / Medium range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short range"
+                    }
+                ],
+                "filename": "mig-19.png"
+            },
+            "MiG-21Bis": {
+                "name": "MiG-21Bis",
+                "coalition": "Red",
+                "label": "MiG-21 Fishbed",
+                "era": "Mid Cold War",
+                "shortLabel": "21",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-3 Atoll",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60 Aphid",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "130 gal tanks",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "ASO-2 Countermeasures",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "Patrol, short range",
+                        "name": "Light / Fox-2 / Short range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-3 Atoll",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60 Aphid",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "210 gal tanks",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "ASO-2 Countermeasures",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "Patrol, medium range",
+                        "name": "Medium / Fox-2 / Medium range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-3R Atoll",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "210 gal tanks",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "ASO-2 Countermeasures",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "Patrol, R-3R Only",
+                        "name": "Medium / Fox-1 / Medium range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "GROM",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-250",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "210 gal tanks",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "ASO-2 Countermeasures",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Few big targets, GROM + BOMBS",
+                        "name": "Heavy / GROM, FAB250 / Medium range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-21.png"
-         },
-         "Mirage-F1EE": {
-            "name": "Mirage-F1EE",
-            "coalition": "Blue",
-            "label": "Mirage-F1EE",
-            "era": "Mid Cold War",
-            "shortLabel": "F1EE",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9JULI",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R530EM",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "1137L Fuel Tank",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "2*AIM9-JULI, 2*R530EM, 1*Fuel Tank",
-                  "name": "Medium / Fox 1 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9JULI",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SAMP 400 LD",
-                        "quantity": 8
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "2*AIM-9JULI, 8*SAMP 400 LD",
-                  "name": "Heavy / SAMP400 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-21.png"
+            },
+            "Mirage-F1EE": {
+                "name": "Mirage-F1EE",
+                "coalition": "Blue",
+                "label": "Mirage-F1EE",
+                "era": "Mid Cold War",
+                "shortLabel": "F1EE",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9JULI",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R530EM",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "1137L Fuel Tank",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "2*AIM9-JULI, 2*R530EM, 1*Fuel Tank",
+                        "name": "Medium / Fox 1 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9JULI",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SAMP 400 LD",
+                                "quantity": 8
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "2*AIM-9JULI, 8*SAMP 400 LD",
+                        "name": "Heavy / SAMP400 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-5.png"
-         },
-         "A-20G": {
-            "name": "A-20G",
-            "coalition": "",
-            "label": "A-20G Havoc",
-            "era": "WW2",
-            "shortLabel": "A20",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "12.7mm M2 HMG",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "500lb Bomb LD",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "500 lb GP bomb LD*4",
-                  "name": "Medium / Bombs / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-5.png"
+            },
+            "A-20G": {
+                "name": "A-20G",
+                "coalition": "",
+                "label": "A-20G Havoc",
+                "era": "WW2",
+                "shortLabel": "A20",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "12.7mm M2 HMG",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "500lb Bomb LD",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "500 lb GP bomb LD*4",
+                        "name": "Medium / Bombs / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "a-20.png"
-         },
-         "Bf-109K-4": {
-            "name": "Bf-109K-4",
-            "coalition": "",
-            "label": "Bf-109K-4 Fritz",
-            "era": "WW2",
-            "shortLabel": "109",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "30mm MK108 Gun",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SC500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "500 lb GP bomb LD*4",
-                  "name": "Medium / Bombs / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "30mm MK108 Gun",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     },
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short Range"
-               }
-            ],
-            "filename": "bf109.png"
-         },
-         "FW-190A8": {
-            "name": "FW-190A8",
-            "coalition": "",
-            "label": "FW-190A8 Bosch",
-            "era": "WW2",
-            "shortLabel": "190A8",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm MG151 Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SD500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "SD 500 A",
-                  "name": "Medium / Bombs / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm MG151 Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short Range"
-               }
-            ],
-            "filename": "fw190.png"
-         },
-         "FW-190D9": {
-            "name": "FW-190D9",
-            "coalition": "",
-            "label": "FW-190D9 Jerry",
-            "era": "WW2",
-            "shortLabel": "190D9",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm MG151 Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SC500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "SD 500 A",
-                  "name": "Medium / Bombs / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm MG151 Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "13mm MG131 Gun",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short Range"
-               }
-            ],
-            "filename": "fw190.png"
-         },
-         "MosquitoFBMkVI": {
-            "name": "MosquitoFBMkVI",
-            "coalition": "",
-            "label": "Mosquito FB MkVI",
-            "era": "WW2",
-            "shortLabel": "Mosquito",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm Hispano Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "7.7mm MG",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "500 lb GP Mk.V",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "500 lb GP Short tail",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "500 lb GP Mk.V*2, 500 lb GP Short tail*2",
-                  "name": "Medium / Bombs / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm Hispano Gun",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "7.7mm MG",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Medium Range"
-               }
-            ],
-            "filename": "mosquito.png"
-         },
-         "P-47D-40": {
-            "name": "P-47D-40",
-            "coalition": "",
-            "label": "P-47D Thunderbolt",
-            "era": "WW2",
-            "shortLabel": "P47",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "12.7mm HMG",
-                        "quantity": 8
-                     },
-                     {
-                        "name": "AN-M65",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AN-M65*2",
-                  "name": "Medium / Bombs / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "12.7mm HMG",
-                        "quantity": 8
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Medium Range"
-               }
-            ],
-            "filename": "p-47.png"
-         },
-         "P-51D-30-NA": {
-            "name": "P-51D-30-NA",
-            "coalition": "",
-            "label": "P-51D Mustang",
-            "era": "WW2",
-            "shortLabel": "P51",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "12.7mm HMG",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "HVAR",
-                        "quantity": 10
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "HVAR*10",
-                  "name": "Medium / Rockets / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "12.7mm HMG",
-                        "quantity": 6
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Medium Range"
-               }
-            ],
-            "filename": "p-51.png"
-         },
-         "A-50": {
-            "name": "A-50",
-            "coalition": "Red",
-            "label": "A-50 Mainstay",
-            "era": "Late Cold War",
-            "shortLabel": "A50",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "a-20.png"
+            },
+            "Bf-109K-4": {
+                "name": "Bf-109K-4",
+                "coalition": "",
+                "label": "Bf-109K-4 Fritz",
+                "era": "WW2",
+                "shortLabel": "109",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "30mm MK108 Gun",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SC500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "500 lb GP bomb LD*4",
+                        "name": "Medium / Bombs / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "30mm MK108 Gun",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            },
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short Range"
+                    }
+                ],
+                "filename": "bf109.png"
+            },
+            "FW-190A8": {
+                "name": "FW-190A8",
+                "coalition": "",
+                "label": "FW-190A8 Bosch",
+                "era": "WW2",
+                "shortLabel": "190A8",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm MG151 Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SD500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "SD 500 A",
+                        "name": "Medium / Bombs / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm MG151 Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short Range"
+                    }
+                ],
+                "filename": "fw190.png"
+            },
+            "FW-190D9": {
+                "name": "FW-190D9",
+                "coalition": "",
+                "label": "FW-190D9 Jerry",
+                "era": "WW2",
+                "shortLabel": "190D9",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm MG151 Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SC500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "SD 500 A",
+                        "name": "Medium / Bombs / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm MG151 Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "13mm MG131 Gun",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short Range"
+                    }
+                ],
+                "filename": "fw190.png"
+            },
+            "MosquitoFBMkVI": {
+                "name": "MosquitoFBMkVI",
+                "coalition": "",
+                "label": "Mosquito FB MkVI",
+                "era": "WW2",
+                "shortLabel": "Mosquito",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm Hispano Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "7.7mm MG",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "500 lb GP Mk.V",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "500 lb GP Short tail",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "500 lb GP Mk.V*2, 500 lb GP Short tail*2",
+                        "name": "Medium / Bombs / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm Hispano Gun",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "7.7mm MG",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Medium Range"
+                    }
+                ],
+                "filename": "mosquito.png"
+            },
+            "P-47D-40": {
+                "name": "P-47D-40",
+                "coalition": "",
+                "label": "P-47D Thunderbolt",
+                "era": "WW2",
+                "shortLabel": "P47",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "12.7mm HMG",
+                                "quantity": 8
+                            },
+                            {
+                                "name": "AN-M65",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AN-M65*2",
+                        "name": "Medium / Bombs / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "12.7mm HMG",
+                                "quantity": 8
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Medium Range"
+                    }
+                ],
+                "filename": "p-47.png"
+            },
+            "P-51D-30-NA": {
+                "name": "P-51D-30-NA",
+                "coalition": "",
+                "label": "P-51D Mustang",
+                "era": "WW2",
+                "shortLabel": "P51",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "12.7mm HMG",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "HVAR",
+                                "quantity": 10
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "HVAR*10",
+                        "name": "Medium / Rockets / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "12.7mm HMG",
+                                "quantity": 6
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Medium Range"
+                    }
+                ],
+                "filename": "p-51.png"
+            },
+            "A-50": {
+                "name": "A-50",
+                "coalition": "Red",
+                "label": "A-50 Mainstay",
+                "era": "Late Cold War",
+                "shortLabel": "A50",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "AWACS"
-                  ],
-                  "code": "",
-                  "name": "Default AWACS"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "AWACS"
+                        ],
+                        "code": "",
+                        "name": "Default AWACS"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "a-50.png"
-         },
-         "An-26B": {
-            "name": "An-26B",
-            "coalition": "Red",
-            "label": "An-26B Curl",
-            "era": "Mid Cold War",
-            "shortLabel": "26",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "a-50.png"
+            },
+            "An-26B": {
+                "name": "An-26B",
+                "coalition": "Red",
+                "label": "An-26B Curl",
+                "era": "Mid Cold War",
+                "shortLabel": "26",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Default Transport"
-               }
-            ],
-            "filename": "an-26.png"
-         },
-         "An-30M": {
-            "name": "An-30M",
-            "coalition": "Red",
-            "label": "An-30M Clank",
-            "era": "Mid Cold War",
-            "shortLabel": "30",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Default Transport"
+                    }
+                ],
+                "filename": "an-26.png"
+            },
+            "An-30M": {
+                "name": "An-30M",
+                "coalition": "Red",
+                "label": "An-30M Clank",
+                "era": "Mid Cold War",
+                "shortLabel": "30",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Reconnaissance"
-                  ],
-                  "code": "",
-                  "name": "Default Reconnaissance"
-               }
-            ],
-            "filename": "a-50.png"
-         },
-         "B-1B": {
-            "name": "B-1B",
-            "coalition": "Blue",
-            "label": "B-1B Lancer",
-            "era": "Late Cold War",
-            "shortLabel": "1",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Mk-84",
-                        "quantity": 24
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Mk-84*24",
-                  "name": "Heavy / Mk-84 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Reconnaissance"
+                        ],
+                        "code": "",
+                        "name": "Default Reconnaissance"
+                    }
+                ],
+                "filename": "a-50.png"
+            },
+            "B-1B": {
+                "name": "B-1B",
+                "coalition": "Blue",
+                "label": "B-1B Lancer",
+                "era": "Late Cold War",
+                "shortLabel": "1",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Mk-84",
+                                "quantity": 24
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Mk-84*24",
+                        "name": "Heavy / Mk-84 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "b-1.png"
-         },
-         "B-52H": {
-            "name": "B-52H",
-            "coalition": "Blue",
-            "label": "B-52H Stratofortress",
-            "era": "Early Cold War",
-            "shortLabel": "52",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Mk-84",
-                        "quantity": 18
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Mk-84*18",
-                  "name": "Heavy / Mk-84 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "b-1.png"
+            },
+            "B-52H": {
+                "name": "B-52H",
+                "coalition": "Blue",
+                "label": "B-52H Stratofortress",
+                "era": "Early Cold War",
+                "shortLabel": "52",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Mk-84",
+                                "quantity": 18
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Mk-84*18",
+                        "name": "Heavy / Mk-84 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "b-52.png"
-         },
-         "C-130": {
-            "name": "C-130",
-            "coalition": "Blue",
-            "label": "C-130 Hercules",
-            "era": "Early Cold War",
-            "shortLabel": "130",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "b-52.png"
+            },
+            "C-130": {
+                "name": "C-130",
+                "coalition": "Blue",
+                "label": "C-130 Hercules",
+                "era": "Early Cold War",
+                "shortLabel": "130",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "C-130",
-                  "name": "Default Transport"
-               }
-            ],
-            "filename": "c-130.png"
-         },
-         "C-17A": {
-            "name": "C-17A",
-            "coalition": "Blue",
-            "label": "C-17A Globemaster",
-            "era": "Modern",
-            "shortLabel": "C17",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "C-130",
+                        "name": "Default Transport"
+                    }
+                ],
+                "filename": "c-130.png"
+            },
+            "C-17A": {
+                "name": "C-17A",
+                "coalition": "Blue",
+                "label": "C-17A Globemaster",
+                "era": "Modern",
+                "shortLabel": "C17",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Default Transport"
-               }
-            ],
-            "filename": "c-17.png"
-         },
-         "E-3A": {
-            "name": "E-3A",
-            "coalition": "Blue",
-            "label": "E-3A Sentry",
-            "era": "Mid Cold War",
-            "shortLabel": "E3",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Default Transport"
+                    }
+                ],
+                "filename": "c-17.png"
+            },
+            "E-3A": {
+                "name": "E-3A",
+                "coalition": "Blue",
+                "label": "E-3A Sentry",
+                "era": "Mid Cold War",
+                "shortLabel": "E3",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "AWACS"
-                  ],
-                  "code": "",
-                  "name": "Blue Air Force AWACS"
-               }
-            ],
-            "filename": "e-3.png"
-         },
-         "E-2C": {
-            "name": "E-2C",
-            "coalition": "Blue",
-            "label": "E-2C Hawkeye",
-            "era": "Mid Cold War",
-            "shortLabel": "2C",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "AWACS"
+                        ],
+                        "code": "",
+                        "name": "Blue Air Force AWACS"
+                    }
+                ],
+                "filename": "e-3.png"
+            },
+            "E-2C": {
+                "name": "E-2C",
+                "coalition": "Blue",
+                "label": "E-2C Hawkeye",
+                "era": "Mid Cold War",
+                "shortLabel": "2C",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "AWACS"
-                  ],
-                  "code": "",
-                  "name": "Blue Navy AWACS"
-               }
-            ],
-            "filename": "e-2.png"
-         },
-         "F-117A": {
-            "name": "F-117A",
-            "coalition": "Blue",
-            "label": "F-117A Nighthawk",
-            "era": "Late Cold War",
-            "shortLabel": "117",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "GBU-10",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "GBU-10*2",
-                  "name": "Heavy / GBU-10 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "AWACS"
+                        ],
+                        "code": "",
+                        "name": "Blue Navy AWACS"
+                    }
+                ],
+                "filename": "e-2.png"
+            },
+            "F-117A": {
+                "name": "F-117A",
+                "coalition": "Blue",
+                "label": "F-117A Nighthawk",
+                "era": "Late Cold War",
+                "shortLabel": "117",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "GBU-10",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "GBU-10*2",
+                        "name": "Heavy / GBU-10 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-117.png"
-         },
-         "F-15C": {
-            "name": "F-15C",
-            "coalition": "Blue",
-            "label": "F-15C Eagle",
-            "era": "Late Cold War",
-            "shortLabel": "15",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-120B",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9*2,AIM-120*6,Fuel*3",
-                  "name": "Heavy / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-7",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9*4,AIM-7*4,Fuel",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-117.png"
+            },
+            "F-15C": {
+                "name": "F-15C",
+                "coalition": "Blue",
+                "label": "F-15C Eagle",
+                "era": "Late Cold War",
+                "shortLabel": "15",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-120B",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9*2,AIM-120*6,Fuel*3",
+                        "name": "Heavy / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-7",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9*4,AIM-7*4,Fuel",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-15.png"
-         },
-         "F-15E": {
-            "name": "F-15E",
-            "coalition": "Blue",
-            "label": "F-15E Strike Eagle",
-            "era": "Late Cold War",
-            "shortLabel": "15",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 3
-                     },
-                     {
-                        "name": "AIM-120B",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk-84",
-                        "quantity": 8
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AIM-120B*2,AIM-9M*2,FUEL*3,Mk-84*8",
-                  "name": "Heavy / Fox 3, Mk-84 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-120B",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-12",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "GBU-38",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AGM-154C",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "AIM-120B*2,AIM-9M*2,FUEL,GBU-12*4,GBU-38*4,AGM-154C*2",
-                  "name": "Heavy / Fox 3, GBU-12, GBU-38, AGM-154C / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-15.png"
+            },
+            "F-15E": {
+                "name": "F-15E",
+                "coalition": "Blue",
+                "label": "F-15E Strike Eagle",
+                "era": "Late Cold War",
+                "shortLabel": "15",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 3
+                            },
+                            {
+                                "name": "AIM-120B",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk-84",
+                                "quantity": 8
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AIM-120B*2,AIM-9M*2,FUEL*3,Mk-84*8",
+                        "name": "Heavy / Fox 3, Mk-84 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-120B",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-12",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "GBU-38",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AGM-154C",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "AIM-120B*2,AIM-9M*2,FUEL,GBU-12*4,GBU-38*4,AGM-154C*2",
+                        "name": "Heavy / Fox 3, GBU-12, GBU-38, AGM-154C / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-15.png"
-         },
-         "F-4E": {
-            "name": "F-4E",
-            "coalition": "Blue",
-            "label": "F-4E Phantom II",
-            "era": "Mid Cold War",
-            "shortLabel": "4",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "AIM-9*4,AIM-7*4,Fuel*2",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk-82",
-                        "quantity": 18
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Mk-82*18,AIM-7*2,ECM",
-                  "name": "Heavy / Fox 1, Mk-82 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "AIM-7M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "AGM-65K",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "Fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AGM-65K*4,AIM-7*2,Fuel*2,ECM",
-                  "name": "Heavy / Fox 1, AGM-65K / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-15.png"
+            },
+            "F-4E": {
+                "name": "F-4E",
+                "coalition": "Blue",
+                "label": "F-4E Phantom II",
+                "era": "Mid Cold War",
+                "shortLabel": "4",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "AIM-9*4,AIM-7*4,Fuel*2",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk-82",
+                                "quantity": 18
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Mk-82*18,AIM-7*2,ECM",
+                        "name": "Heavy / Fox 1, Mk-82 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "AIM-7M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "AGM-65K",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "Fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AGM-65K*4,AIM-7*2,Fuel*2,ECM",
+                        "name": "Heavy / Fox 1, AGM-65K / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "f-4.png"
-         },
-         "IL-76MD": {
-            "name": "IL-76MD",
-            "coalition": "Red",
-            "label": "IL-76MD Candid",
-            "era": "Mid Cold War",
-            "shortLabel": "76",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "f-4.png"
+            },
+            "IL-76MD": {
+                "name": "IL-76MD",
+                "coalition": "Red",
+                "label": "IL-76MD Candid",
+                "era": "Mid Cold War",
+                "shortLabel": "76",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Default Transport"
-               }
-            ],
-            "filename": "il-76.png"
-         },
-         "IL-78M": {
-            "name": "IL-78M",
-            "coalition": "Red",
-            "label": "IL-78M Midas",
-            "era": "Late Cold War",
-            "shortLabel": "78",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Default Transport"
+                    }
+                ],
+                "filename": "il-76.png"
+            },
+            "IL-78M": {
+                "name": "IL-78M",
+                "coalition": "Red",
+                "label": "IL-78M Midas",
+                "era": "Late Cold War",
+                "shortLabel": "78",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Tanker"
-                  ],
-                  "code": "",
-                  "name": "Default Tanker"
-               }
-            ],
-            "filename": "il-76.png"
-         },
-         "KC-135": {
-            "name": "KC-135",
-            "coalition": "Blue",
-            "label": "KC-135 Stratotanker",
-            "era": "Early Cold War",
-            "shortLabel": "135",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Tanker"
+                        ],
+                        "code": "",
+                        "name": "Default Tanker"
+                    }
+                ],
+                "filename": "il-76.png"
+            },
+            "KC-135": {
+                "name": "KC-135",
+                "coalition": "Blue",
+                "label": "KC-135 Stratotanker",
+                "era": "Early Cold War",
+                "shortLabel": "135",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Tanker"
-                  ],
-                  "code": "",
-                  "name": "Default Tanker"
-               }
-            ],
-            "filename": "kc-135.png"
-         },
-         "KC135MPRS": {
-            "name": "KC135MPRS",
-            "coalition": "Blue",
-            "label": "KC-135 MPRS Stratotanker",
-            "era": "Early Cold War",
-            "shortLabel": "135M",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Tanker"
+                        ],
+                        "code": "",
+                        "name": "Default Tanker"
+                    }
+                ],
+                "filename": "kc-135.png"
+            },
+            "KC135MPRS": {
+                "name": "KC135MPRS",
+                "coalition": "Blue",
+                "label": "KC-135 MPRS Stratotanker",
+                "era": "Early Cold War",
+                "shortLabel": "135M",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Tanker"
-                  ],
-                  "code": "",
-                  "name": "Default Tanker"
-               }
-            ],
-            "filename": "kc-135.png"
-         },
-         "S-3B Tanker": {
-            "name": "S-3B Tanker",
-            "coalition": "Blue",
-            "label": "S-3B Tanker",
-            "era": "Early Cold War",
-            "shortLabel": "S3B",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Tanker"
+                        ],
+                        "code": "",
+                        "name": "Default Tanker"
+                    }
+                ],
+                "filename": "kc-135.png"
+            },
+            "S-3B Tanker": {
+                "name": "S-3B Tanker",
+                "coalition": "Blue",
+                "label": "S-3B Tanker",
+                "era": "Early Cold War",
+                "shortLabel": "S3B",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Tanker"
-                  ],
-                  "code": "",
-                  "name": "Default Tanker"
-               }
-            ],
-            "filename": "s-3.png"
-         },
-         "MiG-15bis": {
-            "name": "MiG-15bis",
-            "coalition": "Red",
-            "label": "MiG-15 Fagot",
-            "era": "Early Cold War",
-            "shortLabel": "M15",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "300L Fuel Tanks",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "2*300L",
-                  "name": "Medium / Guns / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-100M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "2*FAB-100M",
-                  "name": "Medium / FAB-100M / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Tanker"
+                        ],
+                        "code": "",
+                        "name": "Default Tanker"
+                    }
+                ],
+                "filename": "s-3.png"
+            },
+            "MiG-15bis": {
+                "name": "MiG-15bis",
+                "coalition": "Red",
+                "label": "MiG-15 Fagot",
+                "era": "Early Cold War",
+                "shortLabel": "M15",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "300L Fuel Tanks",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "2*300L",
+                        "name": "Medium / Guns / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-100M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "2*FAB-100M",
+                        "name": "Medium / FAB-100M / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "",
-                  "name": "Light / Guns / Short Range"
-               },
-            ],
-            "filename": "mig-15.png"
-         },
-         "MiG-23MLD": {
-            "name": "MiG-23MLD",
-            "coalition": "Red",
-            "label": "MiG-23 Flogger",
-            "era": "Mid Cold War",
-            "shortLabel": "23",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Fuel-800",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-24R",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-24R*2,R-60M*4,Fuel-800",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Fuel-800",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "FAB-500",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500*2,R-60M*2,Fuel-800",
-                  "name": "Heavy / FAB-500 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "",
+                        "name": "Light / Guns / Short Range"
+                    },
+                ],
+                "filename": "mig-15.png"
+            },
+            "MiG-23MLD": {
+                "name": "MiG-23MLD",
+                "coalition": "Red",
+                "label": "MiG-23 Flogger",
+                "era": "Mid Cold War",
+                "shortLabel": "23",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Fuel-800",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-24R",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-24R*2,R-60M*4,Fuel-800",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Fuel-800",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "FAB-500",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500*2,R-60M*2,Fuel-800",
+                        "name": "Heavy / FAB-500 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-23.png"
-         },
-         "MiG-25RBT": {
-            "name": "MiG-25RBT",
-            "coalition": "Red",
-            "label": "MiG-25RBT Foxbat",
-            "era": "Mid Cold War",
-            "shortLabel": "25",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Reconnaissance"
-                  ],
-                  "code": "R-60M*2",
-                  "name": "Heavy / Fox 2 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-500",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500x2_60x2",
-                  "name": "Heavy / FAB-500 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-23.png"
+            },
+            "MiG-25RBT": {
+                "name": "MiG-25RBT",
+                "coalition": "Red",
+                "label": "MiG-25RBT Foxbat",
+                "era": "Mid Cold War",
+                "shortLabel": "25",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Reconnaissance"
+                        ],
+                        "code": "R-60M*2",
+                        "name": "Heavy / Fox 2 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-500",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500x2_60x2",
+                        "name": "Heavy / FAB-500 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-25.png"
-         },
-         "MiG-25PD": {
-            "name": "MiG-25PD",
-            "coalition": "Red",
-            "label": "MiG-25PD Foxbat",
-            "era": "Mid Cold War",
-            "shortLabel": "25",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-40R",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-40R*2,R-60M*2",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-25.png"
+            },
+            "MiG-25PD": {
+                "name": "MiG-25PD",
+                "coalition": "Red",
+                "label": "MiG-25PD Foxbat",
+                "era": "Mid Cold War",
+                "shortLabel": "25",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-40R",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-40R*2,R-60M*2",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-25.png"
-         },
-         "MiG-27K": {
-            "name": "MiG-27K",
-            "coalition": "Red",
-            "label": "MiG-27K Flogger-D",
-            "era": "Mid Cold War",
-            "shortLabel": "27",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "B-8",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "B-8*4",
-                  "name": "Heavy / B-8 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-29L",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Kh-29L*2,R-60M*2,Fuel",
-                  "name": "Heavy / Fox 2, Kh-29L / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-250",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-250*6,R-60M*2,Fuel",
-                  "name": "Heavy / Fox 2, FAB250 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-25.png"
+            },
+            "MiG-27K": {
+                "name": "MiG-27K",
+                "coalition": "Red",
+                "label": "MiG-27K Flogger-D",
+                "era": "Mid Cold War",
+                "shortLabel": "27",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "B-8",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "B-8*4",
+                        "name": "Heavy / B-8 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-29L",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Kh-29L*2,R-60M*2,Fuel",
+                        "name": "Heavy / Fox 2, Kh-29L / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-250",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-250*6,R-60M*2,Fuel",
+                        "name": "Heavy / Fox 2, FAB250 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-23.png"
-         },
-         "MiG-29A": {
-            "name": "MiG-29A",
-            "coalition": "Red",
-            "label": "MiG-29A Fulcrum",
-            "era": "Late Cold War",
-            "shortLabel": "29A",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-27R",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27R*2,Fuel-1500",
-                  "name": "Heavy / Fox 1, HOBS Fox 2 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-27R",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-60M*4,R-27R*2,Fuel-1500",
-                  "name": "Heavy / Fox 1 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-500",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500*4,R-73*2,Fuel",
-                  "name": "Heavy / Fox 2, FAB500 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-23.png"
+            },
+            "MiG-29A": {
+                "name": "MiG-29A",
+                "coalition": "Red",
+                "label": "MiG-29A Fulcrum",
+                "era": "Late Cold War",
+                "shortLabel": "29A",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-27R",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27R*2,Fuel-1500",
+                        "name": "Heavy / Fox 1, HOBS Fox 2 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-27R",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-60M*4,R-27R*2,Fuel-1500",
+                        "name": "Heavy / Fox 1 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-500",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500*4,R-73*2,Fuel",
+                        "name": "Heavy / Fox 2, FAB500 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-29.png"
-         },
-         "MiG-29S": {
-            "name": "MiG-29S",
-            "coalition": "Red",
-            "label": "MiG-29S Fulcrum",
-            "era": "Late Cold War",
-            "shortLabel": "29",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-27R",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27R*2,Fuel-1500",
-                  "name": "Heavy / Fox 1 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-27R",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-60M*4,R-27R*2",
-                  "name": "Heavy / Fox 1 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "S-24",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "S-24*4,R-73*2,Fuel",
-                  "name": "Heavy / Fox 2, S-24 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-500",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "Fuel-1500",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500*4,R-73*2,Fuel",
-                  "name": "Heavy / Fox 2, FAB500 / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-29.png"
+            },
+            "MiG-29S": {
+                "name": "MiG-29S",
+                "coalition": "Red",
+                "label": "MiG-29S Fulcrum",
+                "era": "Late Cold War",
+                "shortLabel": "29",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-27R",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27R*2,Fuel-1500",
+                        "name": "Heavy / Fox 1 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-27R",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-60M*4,R-27R*2",
+                        "name": "Heavy / Fox 1 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "S-24",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "S-24*4,R-73*2,Fuel",
+                        "name": "Heavy / Fox 2, S-24 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-500",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "Fuel-1500",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500*4,R-73*2,Fuel",
+                        "name": "Heavy / Fox 2, FAB500 / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-29.png"
-         },
-         "MiG-31": {
-            "name": "MiG-31",
-            "coalition": "Red",
-            "label": "MiG-31 Foxhound",
-            "era": "Late Cold War",
-            "shortLabel": "31",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-33",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-40T",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-40T*2,R-33*4",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-29.png"
+            },
+            "MiG-31": {
+                "name": "MiG-31",
+                "coalition": "Red",
+                "label": "MiG-31 Foxhound",
+                "era": "Late Cold War",
+                "shortLabel": "31",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-33",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-40T",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-40T*2,R-33*4",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mig-23.png"
-         },
-         "MQ-9 Reaper": {
-            "name": "MQ-9 Reaper",
-            "coalition": "Blue",
-            "label": "MQ-9 Reaper",
-            "era": "Modern",
-            "shortLabel": "9",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-114K",
-                        "quantity": 12
-                     }
-                  ],
-                  "roles": [
-                     "Drone"
-                  ],
-                  "code": "AGM-114K*12",
-                  "name": "Default Drone"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mig-23.png"
+            },
+            "MQ-9 Reaper": {
+                "name": "MQ-9 Reaper",
+                "coalition": "Blue",
+                "label": "MQ-9 Reaper",
+                "era": "Modern",
+                "shortLabel": "9",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-114K",
+                                "quantity": 12
+                            }
+                        ],
+                        "roles": [
+                            "Drone"
+                        ],
+                        "code": "AGM-114K*12",
+                        "name": "Default Drone"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "i-16.png"
-         },
-         "Su-17M4": {
-            "name": "Su-17M4",
-            "coalition": "Red",
-            "label": "Su-17M4 Fitter",
-            "era": "Mid Cold War",
-            "shortLabel": "17M4",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "B-8",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "B-8*4,R-60M*2,Fuel*2",
-                  "name": "Heavy / B-8 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "i-16.png"
+            },
+            "Su-17M4": {
+                "name": "Su-17M4",
+                "coalition": "Red",
+                "label": "Su-17M4 Fitter",
+                "era": "Mid Cold War",
+                "shortLabel": "17M4",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "B-8",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "B-8*4,R-60M*2,Fuel*2",
+                        "name": "Heavy / B-8 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-17.png"
-         },
-         "Su-24M": {
-            "name": "Su-24M",
-            "coalition": "Red",
-            "label": "Su-24M Fencer",
-            "era": "Mid Cold War",
-            "shortLabel": "24",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-1500",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-1500*2,R-60M*2",
-                  "name": "Heavy / FAB-500 / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-17.png"
+            },
+            "Su-24M": {
+                "name": "Su-24M",
+                "coalition": "Red",
+                "label": "Su-24M Fencer",
+                "era": "Mid Cold War",
+                "shortLabel": "24",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-1500",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-1500*2,R-60M*2",
+                        "name": "Heavy / FAB-500 / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-24.png"
-         },
-         "Su-25": {
-            "name": "Su-25",
-            "coalition": "Red",
-            "label": "Su-25A Frogfoot",
-            "era": "Late Cold War",
-            "shortLabel": "S25",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "UB-13",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "UB-13*6,R-60M*2,Fuel*2",
-                  "name": "Heavy / Rockets / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "B-8MI",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "RBK-500",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Kh-25ML",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "2-25L",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "2-25L*2, KH-25ML*2, RBK-500*2, B-8MI*2, R-60M*2",
-                  "name": "Heavy / Everything A-G / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-24.png"
+            },
+            "Su-25": {
+                "name": "Su-25",
+                "coalition": "Red",
+                "label": "Su-25A Frogfoot",
+                "era": "Late Cold War",
+                "shortLabel": "S25",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "UB-13",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "UB-13*6,R-60M*2,Fuel*2",
+                        "name": "Heavy / Rockets / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "B-8MI",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "RBK-500",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Kh-25ML",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "2-25L",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "2-25L*2, KH-25ML*2, RBK-500*2, B-8MI*2, R-60M*2",
+                        "name": "Heavy / Everything A-G / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-25.png"
-         },
-         "Su-25T": {
-            "name": "Su-25",
-            "coalition": "Red",
-            "label": "Su-25T Frogfoot",
-            "era": "Late Cold War",
-            "shortLabel": "S25T",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-29L",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Kh-25ML",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mercury LLTV Pod",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "MPS-410",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "Kh-29L*2,Kh-25ML*4,R-73*2,Mercury LLTV Pod,MPS-410",
-                  "name": "Heavy / Everything A-G / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "APU-8 Vikhr-M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Kh-25ML",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "SPPU-22*2",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mercury LLTV Pod",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "MPS-410",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "APU-8 Vikhr-M*2,Kh-25ML,R-73*2,SPPU-22*2,Mercury LLTV Pod,MPS-410",
-                  "name": "Heavy / Everything A-G / Medium Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-500",
-                        "quantity": 6
-                     },
-                     {
-                        "name": "R-60M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Fuel",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-500*6,R-60M*2,Fuel*2",
-                  "name": "Medium / FAB-500 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-25.png"
+            },
+            "Su-25T": {
+                "name": "Su-25",
+                "coalition": "Red",
+                "label": "Su-25T Frogfoot",
+                "era": "Late Cold War",
+                "shortLabel": "S25T",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-29L",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Kh-25ML",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mercury LLTV Pod",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "MPS-410",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "Kh-29L*2,Kh-25ML*4,R-73*2,Mercury LLTV Pod,MPS-410",
+                        "name": "Heavy / Everything A-G / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "APU-8 Vikhr-M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Kh-25ML",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "SPPU-22*2",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mercury LLTV Pod",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "MPS-410",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "APU-8 Vikhr-M*2,Kh-25ML,R-73*2,SPPU-22*2,Mercury LLTV Pod,MPS-410",
+                        "name": "Heavy / Everything A-G / Medium Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-500",
+                                "quantity": 6
+                            },
+                            {
+                                "name": "R-60M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Fuel",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-500*6,R-60M*2,Fuel*2",
+                        "name": "Medium / FAB-500 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-25.png"
-         },
-         "Su-27": {
-            "name": "Su-27",
-            "coalition": "Red",
-            "label": "Su-27 Flanker",
-            "era": "Late Cold War",
-            "shortLabel": "27",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27ER*2,ECM",
-                  "name": "Light / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ET",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27ER*2,R-27ET*2,ECM",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ET",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27ET*2,ECM",
-                  "name": "Heavy / Fox 2 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "S-25",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "FAB-500",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "S-25*4, FAB-500*4, R-73*2, ECM",
-                  "name": "Heavy / Fox 2, Bombs, Rockets / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-25.png"
+            },
+            "Su-27": {
+                "name": "Su-27",
+                "coalition": "Red",
+                "label": "Su-27 Flanker",
+                "era": "Late Cold War",
+                "shortLabel": "27",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27ER*2,ECM",
+                        "name": "Light / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ET",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27ER*2,R-27ET*2,ECM",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ET",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27ET*2,ECM",
+                        "name": "Heavy / Fox 2 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "S-25",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "FAB-500",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "S-25*4, FAB-500*4, R-73*2, ECM",
+                        "name": "Heavy / Fox 2, Bombs, Rockets / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-27.png"
-         },
-         "Su-30": {
-            "name": "Su-30",
-            "coalition": "Red",
-            "label": "Su-30 Super Flanker",
-            "era": "Late Cold War",
-            "shortLabel": "30",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-77",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-77*2",
-                  "name": "Light / Fox 3 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-77",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-77*2,R-27ER*2,ECM",
-                  "name": "Heavy / Fox 3, Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-77",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-1500",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-1500*2,R-73*2,R-77*2,ECM",
-                  "name": "Heavy / Fox 3, Bombs / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-27.png"
+            },
+            "Su-30": {
+                "name": "Su-30",
+                "coalition": "Red",
+                "label": "Su-30 Super Flanker",
+                "era": "Late Cold War",
+                "shortLabel": "30",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-77",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-77*2",
+                        "name": "Light / Fox 3 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-77",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-77*2,R-27ER*2,ECM",
+                        "name": "Heavy / Fox 3, Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-77",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-1500",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-1500*2,R-73*2,R-77*2,ECM",
+                        "name": "Heavy / Fox 3, Bombs / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-34.png"
-         },
-         "Su-33": {
-            "name": "Su-33",
-            "coalition": "Red",
-            "label": "Su-33 Navy Flanker",
-            "era": "Late Cold War",
-            "shortLabel": "33",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2, R-27ER*2",
-                  "name": "Light / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "R-27ER",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "R-73*2,R-27ET*2,R-27ER*2,ECM",
-                  "name": "Heavy / Fox 1 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "S-25",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "FAB-250",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "S-25*4,FAB-250*4,R-73*2,ECM",
-                  "name": "Heavy / Rockets, Bombs / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-34.png"
+            },
+            "Su-33": {
+                "name": "Su-33",
+                "coalition": "Red",
+                "label": "Su-33 Navy Flanker",
+                "era": "Late Cold War",
+                "shortLabel": "33",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2, R-27ER*2",
+                        "name": "Light / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "R-27ER",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "R-73*2,R-27ET*2,R-27ER*2,ECM",
+                        "name": "Heavy / Fox 1 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "S-25",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "FAB-250",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "S-25*4,FAB-250*4,R-73*2,ECM",
+                        "name": "Heavy / Rockets, Bombs / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-34.png"
-         },
-         "Su-34": {
-            "name": "Su-34",
-            "coalition": "Red",
-            "label": "Su-34 Hellduck",
-            "era": "Modern",
-            "shortLabel": "34",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "R-73",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "FAB-250",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "UB-13",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "UB-13*4,FAB-250*4,R-73*2,ECM",
-                  "name": "Heavy / Mixed Ground Ordinance / Short Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-34.png"
+            },
+            "Su-34": {
+                "name": "Su-34",
+                "coalition": "Red",
+                "label": "Su-34 Hellduck",
+                "era": "Modern",
+                "shortLabel": "34",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "R-73",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "FAB-250",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "UB-13",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "UB-13*4,FAB-250*4,R-73*2,ECM",
+                        "name": "Heavy / Mixed Ground Ordinance / Short Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "su-34.png"
-         },
-         "Tornado IDS": {
-            "name": "Tornado IDS",
-            "coalition": "Blue",
-            "label": "Tornado IDS",
-            "era": "Late Cold War",
-            "shortLabel": "IDS",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Mk-82",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "Mk-82*4,AIM-9*2,Fuel*2",
-                  "name": "Heavy / Mk-84 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "su-34.png"
+            },
+            "Tornado IDS": {
+                "name": "Tornado IDS",
+                "coalition": "Blue",
+                "label": "Tornado IDS",
+                "era": "Late Cold War",
+                "shortLabel": "IDS",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Mk-82",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "Mk-82*4,AIM-9*2,Fuel*2",
+                        "name": "Heavy / Mk-84 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tornado.png"
-         },
-         "Tornado GR4": {
-            "name": "Tornado GR4",
-            "coalition": "Blue",
-            "label": "Tornado GR4",
-            "era": "Late Cold War",
-            "shortLabel": "GR4",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "ALARM",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "SEAD"
-                  ],
-                  "code": "ALARM*4, Fuel*2, ECM",
-                  "name": "Heavy / ALARM / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "GBU-16",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "GBU-16*2, AIM-9M*2, Fuel*2, ECM",
-                  "name": "Heavy / GBU-16 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AIM-9M",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "Sea Eagle",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "fuel",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "ECM",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "Sea Eagle*2, AIM-9M*2, Fuel*2, ECM",
-                  "name": "Heavy / Sea Eagle / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tornado.png"
+            },
+            "Tornado GR4": {
+                "name": "Tornado GR4",
+                "coalition": "Blue",
+                "label": "Tornado GR4",
+                "era": "Late Cold War",
+                "shortLabel": "GR4",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "ALARM",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "SEAD"
+                        ],
+                        "code": "ALARM*4, Fuel*2, ECM",
+                        "name": "Heavy / ALARM / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "GBU-16",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "GBU-16*2, AIM-9M*2, Fuel*2, ECM",
+                        "name": "Heavy / GBU-16 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AIM-9M",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "Sea Eagle",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "fuel",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "ECM",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "Sea Eagle*2, AIM-9M*2, Fuel*2, ECM",
+                        "name": "Heavy / Sea Eagle / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tornado.png"
-         },
-         "Tu-142": {
-            "name": "Tu-142",
-            "coalition": "Red",
-            "label": "Tu-142 Bear",
-            "era": "Mid Cold War",
-            "shortLabel": "142",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-35",
-                        "quantity": 6
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "Kh-35*6",
-                  "name": "Heavy / Kh-35 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tornado.png"
+            },
+            "Tu-142": {
+                "name": "Tu-142",
+                "coalition": "Red",
+                "label": "Tu-142 Bear",
+                "era": "Mid Cold War",
+                "shortLabel": "142",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-35",
+                                "quantity": 6
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "Kh-35*6",
+                        "name": "Heavy / Kh-35 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tu-95.png"
-         },
-         "Tu-160": {
-            "name": "Tu-160",
-            "coalition": "Red",
-            "label": "Tu-160 Blackjack",
-            "era": "Late Cold War",
-            "shortLabel": "160",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-65",
-                        "quantity": 12
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "Kh-65*12",
-                  "name": "Heavy / Kh-65 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tu-95.png"
+            },
+            "Tu-160": {
+                "name": "Tu-160",
+                "coalition": "Red",
+                "label": "Tu-160 Blackjack",
+                "era": "Late Cold War",
+                "shortLabel": "160",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-65",
+                                "quantity": 12
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "Kh-65*12",
+                        "name": "Heavy / Kh-65 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tu-160.png"
-         },
-         "Tu-22M3": {
-            "name": "Tu-22M3",
-            "coalition": "Red",
-            "label": "Tu-22M3 Backfire",
-            "era": "Late Cold War",
-            "shortLabel": "T22",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-22n",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "Kh-22N*2",
-                  "name": "Heavy / Kh-22N / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "FAB-250",
-                        "quantity": 69
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "FAB-250*69",
-                  "name": "Heavy / Kh-22n / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tu-160.png"
+            },
+            "Tu-22M3": {
+                "name": "Tu-22M3",
+                "coalition": "Red",
+                "label": "Tu-22M3 Backfire",
+                "era": "Late Cold War",
+                "shortLabel": "T22",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-22n",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "Kh-22N*2",
+                        "name": "Heavy / Kh-22N / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "FAB-250",
+                                "quantity": 69
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "FAB-250*69",
+                        "name": "Heavy / Kh-22n / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tu-22.png"
-         },
-         "Tu-95MS": {
-            "name": "Tu-95MS",
-            "coalition": "Red",
-            "label": "Tu-95MS Bear",
-            "era": "Mid Cold War",
-            "shortLabel": "95",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Kh-65",
-                        "quantity": 6
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "Kh-65*6",
-                  "name": "Heavy / Kh-65 / Long Range"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tu-22.png"
+            },
+            "Tu-95MS": {
+                "name": "Tu-95MS",
+                "coalition": "Red",
+                "label": "Tu-95MS Bear",
+                "era": "Mid Cold War",
+                "shortLabel": "95",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Kh-65",
+                                "quantity": 6
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "Kh-65*6",
+                        "name": "Heavy / Kh-65 / Long Range"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "tu-95.png"
-         }
-      }
-   }
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "tu-95.png"
+            }
+        }
+    }
 }
 
 export var aircraftDatabase = new AircraftDatabase();

--- a/client/src/units/groundunitdatabase.ts
+++ b/client/src/units/groundunitdatabase.ts
@@ -6,9 +6,8 @@ export class GroundUnitDatabase extends UnitDatabase {
         this.blueprints = {
             "SA-2 SAM Battery": {
                 "name": "SA-2 SAM Battery",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "SA-2 SAM Battery",
                 "shortLabel": "SA-2 SAM Battery",
                 "range": "Long",
@@ -17,9 +16,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-3 SAM Battery": {
                 "name": "SA-3 SAM Battery",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "SA-3 SAM Battery",
                 "shortLabel": "SA-3 SAM Battery",
                 "range": "Medium",
@@ -28,9 +26,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-6 SAM Battery": {
                 "name": "SA-6 SAM Battery",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SA-6 SAM Battery",
                 "shortLabel": "SA-6 SAM Battery",
                 "range": "Medium",
@@ -39,9 +36,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-10 SAM Battery": {
                 "name": "SA-10 SAM Battery",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 SAM Battery",
                 "shortLabel": "SA-10 SAM Battery",
                 "range": "Long",
@@ -50,9 +46,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-11 SAM Battery": {
                 "name": "SA-11 SAM Battery",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-11 SAM Battery",
                 "shortLabel": "SA-11 SAM Battery",
                 "range": "Medium",
@@ -61,9 +56,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot site": {
                 "name": "Patriot site",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Patriot site",
                 "shortLabel": "Patriot site",
                 "range": "Long",
@@ -72,9 +66,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk SAM Battery": {
                 "name": "Hawk SAM Battery",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "Hawk SAM Battery",
                 "shortLabel": "Hawk SAM Battery",
                 "range": "Medium",
@@ -83,9 +76,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "2B11 mortar": {
                 "name": "2B11 mortar",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "2B11 mortar",
                 "shortLabel": "2B11 mortar",
                 "filename": "",
@@ -93,9 +85,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SAU Gvozdika": {
                 "name": "SAU Gvozdika",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SAU Gvozdika",
                 "shortLabel": "SAU Gvozdika",
                 "filename": "",
@@ -103,9 +94,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SAU Msta": {
                 "name": "SAU Msta",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SAU Msta",
                 "shortLabel": "SAU Msta",
                 "filename": "",
@@ -113,9 +103,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SAU Akatsia": {
                 "name": "SAU Akatsia",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SAU Akatsia",
                 "shortLabel": "SAU Akatsia",
                 "filename": "",
@@ -123,9 +112,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SAU 2-C9": {
                 "name": "SAU 2-C9",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SAU Nona",
                 "shortLabel": "SAU Nona",
                 "filename": "",
@@ -133,9 +121,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M-109": {
                 "name": "M-109",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "M-109 Paladin",
                 "shortLabel": "M-109",
                 "filename": "",
@@ -143,9 +130,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "AAV7": {
                 "name": "AAV7",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "AAV7",
                 "shortLabel": "AAV7",
                 "filename": "",
@@ -153,9 +139,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BMD-1": {
                 "name": "BMD-1",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "BMD-1",
                 "shortLabel": "BMD-1",
                 "filename": "",
@@ -163,9 +148,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BMP-1": {
                 "name": "BMP-1",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "BMP-1",
                 "shortLabel": "BMP-1",
                 "filename": "",
@@ -173,9 +157,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BMP-2": {
                 "name": "BMP-2",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "BMP-2",
                 "shortLabel": "BMP-2",
                 "filename": "",
@@ -183,9 +166,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BMP-3": {
                 "name": "BMP-3",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "BMP-3",
                 "shortLabel": "BMP-3",
                 "filename": "",
@@ -193,9 +175,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Boman": {
                 "name": "Boman",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Grad Fire Direction Manager",
                 "shortLabel": "Boman",
                 "filename": "",
@@ -203,9 +184,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BRDM-2": {
                 "name": "BRDM-2",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "BRDM-2",
                 "shortLabel": "BRDM-2",
                 "filename": "",
@@ -213,9 +193,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BTR-80": {
                 "name": "BTR-80",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "BTR-80",
                 "shortLabel": "BTR-80",
                 "filename": "",
@@ -223,9 +202,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "BTR_D": {
                 "name": "BTR_D",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "BTR_D",
                 "shortLabel": "BTR_D",
                 "filename": "",
@@ -233,7 +211,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Bunker": {
                 "name": "Bunker",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "Bunker",
                 "shortLabel": "Bunker",
                 "filename": "",
@@ -241,9 +220,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Cobra": {
                 "name": "Cobra",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Otokar Cobra",
                 "shortLabel": "Cobra",
                 "filename": "",
@@ -251,9 +229,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "LAV-25": {
                 "name": "LAV-25",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "LAV-25",
                 "shortLabel": "LAV-25",
                 "filename": "",
@@ -261,9 +238,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1043 HMMWV Armament": {
                 "name": "M1043 HMMWV Armament",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "HMMWV M2 Browning",
                 "shortLabel": "HMMWV M2",
                 "filename": "",
@@ -271,9 +247,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1045 HMMWV TOW": {
                 "name": "M1045 HMMWV TOW",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "HMMWV TOW",
                 "shortLabel": "HMMWV TOW",
                 "filename": "",
@@ -281,9 +256,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1126 Stryker ICV": {
                 "name": "M1126 Stryker ICV",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Stryker MG",
                 "shortLabel": "Stryker MG",
                 "filename": "",
@@ -291,9 +265,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M-113": {
                 "name": "M-113",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "M-113",
                 "shortLabel": "M-113",
                 "filename": "",
@@ -301,9 +274,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1134 Stryker ATGM": {
                 "name": "M1134 Stryker ATGM",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Stryker ATGM",
                 "shortLabel": "Stryker ATGM",
                 "filename": "",
@@ -311,9 +283,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M-2 Bradley": {
                 "name": "M-2 Bradley",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "M-2A2 Bradley",
                 "shortLabel": "M-2 Bradley",
                 "filename": "",
@@ -321,9 +292,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Marder": {
                 "name": "Marder",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Marder",
                 "shortLabel": "Marder",
                 "filename": "",
@@ -331,9 +301,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "MCV-80": {
                 "name": "MCV-80",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Warrior IFV",
                 "shortLabel": "Warrior",
                 "filename": "",
@@ -341,9 +310,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "MTLB": {
                 "name": "MTLB",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "MT-LB",
                 "shortLabel": "MT-LB",
                 "filename": "",
@@ -351,9 +319,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Paratrooper RPG-16": {
                 "name": "Paratrooper RPG-16",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Red",
+                "era": "Modern",
                 "label": "Paratrooper RPG-16",
                 "shortLabel": "Paratrooper RPG-16",
                 "filename": "",
@@ -361,9 +328,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Paratrooper AKS-74": {
                 "name": "Paratrooper AKS-74",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Red",
+                "era": "Modern",
                 "label": "Paratrooper AKS-74",
                 "shortLabel": "Paratrooper AKS-74",
                 "filename": "",
@@ -371,7 +337,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Sandbox": {
                 "name": "Sandbox",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "Sandbox",
                 "shortLabel": "Sandbox",
                 "filename": "",
@@ -379,9 +346,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Soldier AK": {
                 "name": "Soldier AK",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "Soldier AK",
                 "shortLabel": "Soldier AK",
                 "filename": "",
@@ -389,9 +355,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Infantry AK": {
                 "name": "Infantry AK",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Infantry AK",
                 "shortLabel": "Infantry AK",
                 "filename": "",
@@ -399,9 +364,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Soldier M249": {
                 "name": "Soldier M249",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Soldier M249",
                 "shortLabel": "Soldier M249",
                 "filename": "",
@@ -409,9 +373,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Soldier M4": {
                 "name": "Soldier M4",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "Soldier M4",
                 "shortLabel": "Soldier M4",
                 "filename": "",
@@ -419,9 +382,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Soldier M4 GRG": {
                 "name": "Soldier M4 GRG",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "Soldier M4 GRG",
                 "shortLabel": "Soldier M4 GRG",
                 "filename": "",
@@ -429,9 +391,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Soldier RPG": {
                 "name": "Soldier RPG",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Soldier RPG",
                 "shortLabel": "Soldier RPG",
                 "filename": "",
@@ -439,9 +400,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "TPZ": {
                 "name": "TPZ",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "TPz Fuchs",
                 "shortLabel": "TPz Fuchs",
                 "filename": "",
@@ -449,9 +409,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Grad-URAL": {
                 "name": "Grad-URAL",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Grad",
                 "shortLabel": "Grad",
                 "filename": "",
@@ -459,9 +418,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Uragan_BM-27": {
                 "name": "Uragan_BM-27",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Uragan",
                 "shortLabel": "Uragan",
                 "filename": "",
@@ -469,9 +427,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Smerch": {
                 "name": "Smerch",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Smerch",
                 "shortLabel": "Smerch",
                 "filename": "",
@@ -479,9 +436,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "MLRS": {
                 "name": "MLRS",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "M270",
                 "shortLabel": "M270",
                 "filename": "",
@@ -489,9 +445,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "2S6 Tunguska": {
                 "name": "2S6 Tunguska",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-19 Tunguska",
                 "shortLabel": "SA-19",
                 "range": "Short",
@@ -500,9 +455,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Kub 2P25 ln": {
                 "name": "Kub 2P25 ln",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-6 Kub 2P25 ln",
                 "shortLabel": "Kub 2P25 ln",
                 "range": "Medium",
@@ -511,9 +465,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "5p73 s-125 ln": {
                 "name": "5p73 s-125 ln",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "SA-3 5p73 s-125 ln",
                 "shortLabel": "5p73 s-125 ln",
                 "range": "Medium",
@@ -522,9 +475,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 5P85C ln": {
                 "name": "S-300PS 5P85C ln",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 5P85C ln",
                 "shortLabel": "S-300PS 5P85C ln",
                 "range": "Long",
@@ -533,9 +485,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 5P85D ln": {
                 "name": "S-300PS 5P85D ln",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 5P85D ln",
                 "shortLabel": "S-300PS 5P85D ln",
                 "range": "Long",
@@ -544,9 +495,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-11 Buk LN 9A310M1": {
                 "name": "SA-11 Buk LN 9A310M1",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-11 Buk LN 9A310M1",
                 "shortLabel": "SA-11 Buk LN 9A310M1",
                 "range": "Medium",
@@ -555,9 +505,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Osa 9A33 ln": {
                 "name": "Osa 9A33 ln",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SA-8 Osa 9A33 ln",
                 "shortLabel": "Osa 9A33 ln",
                 "range": "Short",
@@ -566,9 +515,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Tor 9A331": {
                 "name": "Tor 9A331",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-15 Tor 9A331",
                 "shortLabel": "Tor 9A331",
                 "range": "Medium",
@@ -577,9 +525,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Strela-10M3": {
                 "name": "Strela-10M3",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-13 Strela-10M3",
                 "shortLabel": "Strela-10M3",
                 "range": "Short",
@@ -588,9 +535,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Strela-1 9P31": {
                 "name": "Strela-1 9P31",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-9 Strela-1 9P31",
                 "shortLabel": "Strela-1 9P31",
                 "range": "Short",
@@ -599,9 +545,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-11 Buk CC 9S470M1": {
                 "name": "SA-11 Buk CC 9S470M1",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-11 Buk CC 9S470M1",
                 "shortLabel": "SA-11 Buk CC 9S470M1",
                 "range": "Medium",
@@ -610,9 +555,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-8 Osa LD 9T217": {
                 "name": "SA-8 Osa LD 9T217",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-8 Osa LD 9T217",
                 "shortLabel": "SA-8 Osa LD 9T217",
                 "range": "Short",
@@ -621,9 +565,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot AMG": {
                 "name": "Patriot AMG",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Patriot AMG",
                 "shortLabel": "Patriot AMG",
                 "range": "Long",
@@ -632,9 +575,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot ECS": {
                 "name": "Patriot ECS",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Patriot ECS",
                 "shortLabel": "Patriot ECS",
                 "range": "Long",
@@ -643,10 +585,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Gepard": {
                 "name": "Gepard",
-                "era": [
-                    "Late Cold War",
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Gepard",
                 "shortLabel": "Gepard",
                 "filename": "",
@@ -654,9 +594,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk pcp": {
                 "name": "Hawk pcp",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Hawk pcp",
                 "shortLabel": "Hawk pcp",
                 "range": "Medium",
@@ -665,9 +604,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-18 Igla manpad": {
                 "name": "SA-18 Igla manpad",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-18 Igla manpad",
                 "shortLabel": "SA-18 Igla manpad",
                 "range": "Short",
@@ -676,9 +614,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Igla manpad INS": {
                 "name": "Igla manpad INS",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-18 Igla manpad INS",
                 "shortLabel": "Igla manpad INS",
                 "range": "Short",
@@ -687,9 +624,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-18 Igla-S manpad": {
                 "name": "SA-18 Igla-S manpad",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-18 Igla-S manpad",
                 "shortLabel": "SA-18 Igla-S manpad",
                 "range": "Short",
@@ -698,9 +634,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Vulcan": {
                 "name": "Vulcan",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Vulcan",
                 "shortLabel": "Vulcan",
                 "filename": "",
@@ -708,9 +643,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk ln": {
                 "name": "Hawk ln",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Hawk ln",
                 "shortLabel": "Hawk ln",
                 "filename": "",
@@ -718,9 +652,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M48 Chaparral": {
                 "name": "M48 Chaparral",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "M48 Chaparral",
                 "shortLabel": "M48 Chaparral",
                 "filename": "",
@@ -728,9 +661,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M6 Linebacker": {
                 "name": "M6 Linebacker",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "M6 Linebacker",
                 "shortLabel": "M6 Linebacker",
                 "filename": "",
@@ -738,9 +670,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot ln": {
                 "name": "Patriot ln",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Patriot ln",
                 "shortLabel": "Patriot ln",
                 "range": "Long",
@@ -749,9 +680,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1097 Avenger": {
                 "name": "M1097 Avenger",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "M1097 Avenger",
                 "shortLabel": "M1097 Avenger",
                 "filename": "",
@@ -759,9 +689,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot EPP": {
                 "name": "Patriot EPP",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Patriot EPP",
                 "shortLabel": "Patriot EPP",
                 "range": "Long",
@@ -770,9 +699,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot cp": {
                 "name": "Patriot cp",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Patriot cp",
                 "shortLabel": "Patriot cp",
                 "range": "Long",
@@ -781,9 +709,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Roland ADS": {
                 "name": "Roland ADS",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Roland ADS",
                 "shortLabel": "Roland ADS",
                 "filename": "",
@@ -791,9 +718,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 54K6 cp": {
                 "name": "S-300PS 54K6 cp",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 54K6 cp",
                 "shortLabel": "S-300PS 54K6 cp",
                 "range": "Long",
@@ -802,9 +728,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Stinger manpad GRG": {
                 "name": "Stinger manpad GRG",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Stinger manpad GRG",
                 "shortLabel": "Stinger manpad GRG",
                 "range": "Short",
@@ -813,9 +738,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Stinger manpad dsr": {
                 "name": "Stinger manpad dsr",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Stinger manpad dsr",
                 "shortLabel": "Stinger manpad dsr",
                 "range": "Short",
@@ -824,9 +748,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Stinger comm dsr": {
                 "name": "Stinger comm dsr",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Stinger comm dsr",
                 "shortLabel": "Stinger comm dsr",
                 "range": "Short",
@@ -835,9 +758,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Stinger manpad": {
                 "name": "Stinger manpad",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Stinger manpad",
                 "shortLabel": "Stinger manpad",
                 "range": "Short",
@@ -846,9 +768,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Stinger comm": {
                 "name": "Stinger comm",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Stinger comm",
                 "shortLabel": "Stinger comm",
                 "range": "Short",
@@ -857,9 +778,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZSU-23-4 Shilka": {
                 "name": "ZSU-23-4 Shilka",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "ZSU-23-4 Shilka",
                 "shortLabel": "ZSU-23-4 Shilka",
                 "filename": "",
@@ -867,9 +787,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZU-23 Emplacement Closed": {
                 "name": "ZU-23 Emplacement Closed",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZU-23 Emplacement Closed",
                 "shortLabel": "ZU-23 Emplacement Closed",
                 "filename": "",
@@ -877,9 +796,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZU-23 Emplacement": {
                 "name": "ZU-23 Emplacement",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZU-23 Emplacement",
                 "shortLabel": "ZU-23 Emplacement",
                 "filename": "",
@@ -887,9 +805,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZU-23 Closed Insurgent": {
                 "name": "ZU-23 Closed Insurgent",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZU-23 Closed Insurgent",
                 "shortLabel": "ZU-23 Closed Insurgent",
                 "filename": "",
@@ -897,9 +814,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-375 ZU-23 Insurgent": {
                 "name": "Ural-375 ZU-23 Insurgent",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "Ural-375 ZU-23 Insurgent",
                 "shortLabel": "Ural-375 ZU-23 Insurgent",
                 "filename": "",
@@ -907,9 +823,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZU-23 Insurgent": {
                 "name": "ZU-23 Insurgent",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZU-23 Insurgent",
                 "shortLabel": "ZU-23 Insurgent",
                 "filename": "",
@@ -917,9 +832,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-375 ZU-23": {
                 "name": "Ural-375 ZU-23",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "Ural-375 ZU-23",
                 "shortLabel": "Ural-375 ZU-23",
                 "filename": "",
@@ -927,9 +841,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "1L13 EWR": {
                 "name": "1L13 EWR",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "1L13 EWR",
                 "shortLabel": "1L13 EWR",
                 "filename": "",
@@ -937,9 +850,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Kub 1S91 str": {
                 "name": "Kub 1S91 str",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SA-6 Kub 1S91 str",
                 "shortLabel": "Kub 1S91 str",
                 "range": "Medium",
@@ -948,9 +860,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 40B6M tr": {
                 "name": "S-300PS 40B6M tr",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 40B6M tr",
                 "shortLabel": "S-300PS 40B6M tr",
                 "range": "Long",
@@ -959,9 +870,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 40B6MD sr": {
                 "name": "S-300PS 40B6MD sr",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 40B6MD sr",
                 "shortLabel": "S-300PS 40B6MD sr",
                 "range": "Long",
@@ -970,9 +880,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "55G6 EWR": {
                 "name": "55G6 EWR",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "55G6 EWR",
                 "shortLabel": "55G6 EWR",
                 "filename": "",
@@ -980,9 +889,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "S-300PS 64H6E sr": {
                 "name": "S-300PS 64H6E sr",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "SA-10 S-300PS 64H6E sr",
                 "shortLabel": "S-300PS 64H6E sr",
                 "range": "Long",
@@ -991,9 +899,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SA-11 Buk SR 9S18M1": {
                 "name": "SA-11 Buk SR 9S18M1",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SA-11 Buk SR 9S18M1",
                 "shortLabel": "SA-11 Buk SR 9S18M1",
                 "range": "Long",
@@ -1002,9 +909,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Dog Ear radar": {
                 "name": "Dog Ear radar",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Dog Ear radar",
                 "shortLabel": "Dog Ear radar",
                 "filename": "",
@@ -1012,9 +918,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk tr": {
                 "name": "Hawk tr",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "Hawk tr",
                 "shortLabel": "Hawk tr",
                 "range": "Medium",
@@ -1023,9 +928,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk sr": {
                 "name": "Hawk sr",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "Hawk sr",
                 "shortLabel": "Hawk sr",
                 "range": "Long",
@@ -1034,9 +938,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Patriot str": {
                 "name": "Patriot str",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Patriot str",
                 "shortLabel": "Patriot str",
                 "range": "Medium",
@@ -1045,9 +948,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hawk cwar": {
                 "name": "Hawk cwar",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "Hawk cwar",
                 "shortLabel": "Hawk cwar",
                 "range": "Long",
@@ -1056,9 +958,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "p-19 s-125 sr": {
                 "name": "p-19 s-125 sr",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "SA-3 p-19 s-125 sr",
                 "shortLabel": "p-19 s-125 sr",
                 "filename": "",
@@ -1066,9 +967,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Roland Radar": {
                 "name": "Roland Radar",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "Roland Radar",
                 "shortLabel": "Roland Radar",
                 "filename": "",
@@ -1076,9 +976,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "snr s-125 tr": {
                 "name": "snr s-125 tr",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "SA-3 snr s-125 tr",
                 "shortLabel": "snr s-125 tr",
                 "range": "Medium",
@@ -1087,7 +986,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "house1arm": {
                 "name": "house1arm",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "house1arm",
                 "shortLabel": "house1arm",
                 "filename": "",
@@ -1095,7 +995,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "house2arm": {
                 "name": "house2arm",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "house2arm",
                 "shortLabel": "house2arm",
                 "filename": "",
@@ -1103,7 +1004,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "outpost_road": {
                 "name": "outpost_road",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "outpost_road",
                 "shortLabel": "outpost_road",
                 "filename": "",
@@ -1111,7 +1013,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "outpost": {
                 "name": "outpost",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "outpost",
                 "shortLabel": "outpost",
                 "filename": "",
@@ -1119,7 +1022,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "houseA_arm": {
                 "name": "houseA_arm",
-                "era": ["Early Cold War", "Mid Cold War", "Late Cold War", "Modern"],
+                "coalition": "",
+                "era": "",
                 "label": "houseA_arm",
                 "shortLabel": "houseA_arm",
                 "filename": "",
@@ -1127,9 +1031,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Challenger2": {
                 "name": "Challenger2",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Challenger2",
                 "shortLabel": "Challenger2",
                 "filename": "",
@@ -1137,9 +1040,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Leclerc": {
                 "name": "Leclerc",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "Leclerc",
                 "shortLabel": "Leclerc",
                 "filename": "",
@@ -1147,9 +1049,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Leopard1A3": {
                 "name": "Leopard1A3",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "Leopard1A3",
                 "shortLabel": "Leopard1A3",
                 "filename": "",
@@ -1157,9 +1058,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Leopard-2": {
                 "name": "Leopard-2",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Leopard-2",
                 "shortLabel": "Leopard-2",
                 "filename": "",
@@ -1167,9 +1067,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M-60": {
                 "name": "M-60",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "M-60",
                 "shortLabel": "M-60",
                 "filename": "",
@@ -1177,9 +1076,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M1128 Stryker MGS": {
                 "name": "M1128 Stryker MGS",
-                "era": [
-                    "Modern"
-                ],
+                "coalition": "Blue",
+                "era": "Modern",
                 "label": "M1128 Stryker MGS",
                 "shortLabel": "M1128 Stryker MGS",
                 "filename": "",
@@ -1187,9 +1085,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M-1 Abrams": {
                 "name": "M-1 Abrams",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "M-1 Abrams",
                 "shortLabel": "M-1 Abrams",
                 "filename": "",
@@ -1197,9 +1094,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "T-55": {
                 "name": "T-55",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "T-55",
                 "shortLabel": "T-55",
                 "filename": "",
@@ -1207,9 +1103,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "T-72B": {
                 "name": "T-72B",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "T-72B",
                 "shortLabel": "T-72B",
                 "filename": "",
@@ -1217,9 +1112,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "T-80UD": {
                 "name": "T-80UD",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "T-80UD",
                 "shortLabel": "T-80UD",
                 "filename": "",
@@ -1227,9 +1121,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "T-90": {
                 "name": "T-90",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "T-90",
                 "shortLabel": "T-90",
                 "filename": "",
@@ -1237,9 +1130,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-4320 APA-5D": {
                 "name": "Ural-4320 APA-5D",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "Ural-4320 APA-5D",
                 "shortLabel": "Ural-4320 APA-5D",
                 "filename": "",
@@ -1247,9 +1139,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ATMZ-5": {
                 "name": "ATMZ-5",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ATMZ-5",
                 "shortLabel": "ATMZ-5",
                 "filename": "",
@@ -1257,9 +1148,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ATZ-10": {
                 "name": "ATZ-10",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ATZ-10",
                 "shortLabel": "ATZ-10",
                 "filename": "",
@@ -1267,9 +1157,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "GAZ-3307": {
                 "name": "GAZ-3307",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "GAZ-3307",
                 "shortLabel": "GAZ-3307",
                 "filename": "",
@@ -1277,9 +1166,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "GAZ-3308": {
                 "name": "GAZ-3308",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "GAZ-3308",
                 "shortLabel": "GAZ-3308",
                 "filename": "",
@@ -1287,9 +1175,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "GAZ-66": {
                 "name": "GAZ-66",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "GAZ-66",
                 "shortLabel": "GAZ-66",
                 "filename": "",
@@ -1297,9 +1184,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M978 HEMTT Tanker": {
                 "name": "M978 HEMTT Tanker",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "M978 HEMTT Tanker",
                 "shortLabel": "M978 HEMTT Tanker",
                 "filename": "",
@@ -1307,9 +1193,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "HEMTT TFFT": {
                 "name": "HEMTT TFFT",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "HEMTT TFFT",
                 "shortLabel": "HEMTT TFFT",
                 "filename": "",
@@ -1317,9 +1202,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "IKARUS Bus": {
                 "name": "IKARUS Bus",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "IKARUS Bus",
                 "shortLabel": "IKARUS Bus",
                 "filename": "",
@@ -1327,9 +1211,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "KAMAZ Truck": {
                 "name": "KAMAZ Truck",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "KAMAZ Truck",
                 "shortLabel": "KAMAZ Truck",
                 "filename": "",
@@ -1337,9 +1220,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "LAZ Bus": {
                 "name": "LAZ Bus",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "LAZ Bus",
                 "shortLabel": "LAZ Bus",
                 "filename": "",
@@ -1347,9 +1229,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Hummer": {
                 "name": "Hummer",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Mid Cold War",
                 "label": "Hummer",
                 "shortLabel": "Hummer",
                 "filename": "",
@@ -1357,9 +1238,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "M 818": {
                 "name": "M 818",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Early Cold War",
                 "label": "M 818",
                 "shortLabel": "M 818",
                 "filename": "",
@@ -1367,9 +1247,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "MAZ-6303": {
                 "name": "MAZ-6303",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "MAZ-6303",
                 "shortLabel": "MAZ-6303",
                 "filename": "",
@@ -1377,9 +1256,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Predator GCS": {
                 "name": "Predator GCS",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Predator GCS",
                 "shortLabel": "Predator GCS",
                 "filename": "",
@@ -1387,9 +1265,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Predator TrojanSpirit": {
                 "name": "Predator TrojanSpirit",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Predator TrojanSpirit",
                 "shortLabel": "Predator TrojanSpirit",
                 "filename": "",
@@ -1397,9 +1274,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Suidae": {
                 "name": "Suidae",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "",
+                "era": "Prehistoric",
                 "label": "Suidae",
                 "shortLabel": "Suidae",
                 "filename": "",
@@ -1407,9 +1283,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Tigr_233036": {
                 "name": "Tigr_233036",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Tigr_233036",
                 "shortLabel": "Tigr_233036",
                 "filename": "",
@@ -1417,9 +1292,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Trolley bus": {
                 "name": "Trolley bus",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Blue",
+                "era": "Late Cold War",
                 "label": "Trolley bus",
                 "shortLabel": "Trolley bus",
                 "filename": "",
@@ -1427,9 +1301,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "UAZ-469": {
                 "name": "UAZ-469",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "UAZ-469",
                 "shortLabel": "UAZ-469",
                 "filename": "",
@@ -1437,9 +1310,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural ATsP-6": {
                 "name": "Ural ATsP-6",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Ural ATsP-6",
                 "shortLabel": "Ural ATsP-6",
                 "filename": "",
@@ -1447,9 +1319,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-375 PBU": {
                 "name": "Ural-375 PBU",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Ural-375 PBU",
                 "shortLabel": "Ural-375 PBU",
                 "filename": "",
@@ -1457,9 +1328,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-375": {
                 "name": "Ural-375",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Mid Cold War",
                 "label": "Ural-375",
                 "shortLabel": "Ural-375",
                 "filename": "",
@@ -1467,9 +1337,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-4320-31": {
                 "name": "Ural-4320-31",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Ural-4320-31",
                 "shortLabel": "Ural-4320-31",
                 "filename": "",
@@ -1477,9 +1346,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "Ural-4320T": {
                 "name": "Ural-4320T",
-                "era": [
-                    "Late Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Late Cold War",
                 "label": "Ural-4320T",
                 "shortLabel": "Ural-4320T",
                 "filename": "",
@@ -1487,9 +1355,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "VAZ Car": {
                 "name": "VAZ Car",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "VAZ Car",
                 "shortLabel": "VAZ Car",
                 "filename": "",
@@ -1497,9 +1364,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZiL-131 APA-80": {
                 "name": "ZiL-131 APA-80",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZiL-131 APA-80",
                 "shortLabel": "ZiL-131 APA-80",
                 "filename": "",
@@ -1507,9 +1373,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "SKP-11": {
                 "name": "SKP-11",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "SKP-11",
                 "shortLabel": "SKP-11",
                 "filename": "",
@@ -1517,9 +1382,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZIL-131 KUNG": {
                 "name": "ZIL-131 KUNG",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZIL-131 KUNG",
                 "shortLabel": "ZIL-131 KUNG",
                 "filename": "",
@@ -1527,9 +1391,8 @@ export class GroundUnitDatabase extends UnitDatabase {
             },
             "ZIL-4331": {
                 "name": "ZIL-4331",
-                "era": [
-                    "Early Cold War"
-                ],
+                "coalition": "Red",
+                "era": "Early Cold War",
                 "label": "ZIL-4331",
                 "shortLabel": "ZIL-4331",
                 "filename": "",

--- a/client/src/units/helicopterdatabase.ts
+++ b/client/src/units/helicopterdatabase.ts
@@ -1,583 +1,596 @@
 import { UnitDatabase } from "./unitdatabase"
 
 export class HelicopterDatabase extends UnitDatabase {
-   constructor() {
-      super();
-      this.blueprints = {
-         "AH-64D_BLK_II": {
-            "name": "AH-64D_BLK_II",
-            "era": ["Modern"],
-            "label": "AH-64D Apache",
-            "shortLabel": "AH64",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-114k Hellfire",
-                        "quantity": 8
-                     },
-                     {
-                        "name": "M151 Rocket Pod",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "2 * M261: M151 (6PD), 2 * Hellfire station: 4*AGM-114K",
-                  "name": "Gun / ATGM / Rocket"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-114K Hellfire",
-                        "quantity": 16
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "4 * Hellfire station: 4*AGM-114K",
-                  "name": "Gun / ATGM"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+    constructor() {
+        super();
+        this.blueprints = {
+            "AH-64D_BLK_II": {
+                "name": "AH-64D_BLK_II",
+                "coalition": "Blue",
+                "era": "Modern",
+                "label": "AH-64D Apache",
+                "shortLabel": "AH64",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-114k Hellfire",
+                                "quantity": 8
+                            },
+                            {
+                                "name": "M151 Rocket Pod",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "2 * M261: M151 (6PD), 2 * Hellfire station: 4*AGM-114K",
+                        "name": "Gun / ATGM / Rocket"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-114K Hellfire",
+                                "quantity": 16
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "4 * Hellfire station: 4*AGM-114K",
+                        "name": "Gun / ATGM"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "ah-64.png"
-         },
-         "Ka-50_3": {
-            "name": "Ka-50_3",
-            "era": ["Late Cold War"],
-            "label": "Ka-50 Hokum A",
-            "shortLabel": "K50",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Igla",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "4xIgla",
-                  "name": "Gun / Fox 2"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Igla",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "S-13",
-                        "quantity": 10
-                     },
-                     {
-                        "name": "Kh-25ML",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "Anti-Ship"
-                  ],
-                  "code": "2xKh-25ML, 10xS-13, 4xIgla",
-                  "name": "Gun / ASM / Rockets / Fox 2"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Igla",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "S-80FP",
-                        "quantity": 40
-                     },
-                     {
-                        "name": "Vikhr-M",
-                        "quantity": 12
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "12x9A4172, 40xS-8OFP, 4xIgla",
-                  "name": "Gun / ATGM / Rockets / Fox 2"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Igla",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "S-80FP",
-                        "quantity": 40
-                     },
-                     {
-                        "name": "Vikhr-M",
-                        "quantity": 12
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "12x9A4172, 40xS-8OFP, 4xIgla",
-                  "name": "Gun / ATGM"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Igla",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "FAB-500",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "S-13",
-                        "quantity": 10
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "10xS-13, 2xFAB-500, 4xIgla",
-                  "name": "Gun / Bombs / Rockets / Fox 2"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "ah-64.png"
+            },
+            "Ka-50_3": {
+                "name": "Ka-50_3",
+                "coalition": "Red",
+                "era": "Late Cold War",
+                "label": "Ka-50 Hokum A",
+                "shortLabel": "K50",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Igla",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "4xIgla",
+                        "name": "Gun / Fox 2"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Igla",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "S-13",
+                                "quantity": 10
+                            },
+                            {
+                                "name": "Kh-25ML",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "Anti-Ship"
+                        ],
+                        "code": "2xKh-25ML, 10xS-13, 4xIgla",
+                        "name": "Gun / ASM / Rockets / Fox 2"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Igla",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "S-80FP",
+                                "quantity": 40
+                            },
+                            {
+                                "name": "Vikhr-M",
+                                "quantity": 12
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "12x9A4172, 40xS-8OFP, 4xIgla",
+                        "name": "Gun / ATGM / Rockets / Fox 2"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Igla",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "S-80FP",
+                                "quantity": 40
+                            },
+                            {
+                                "name": "Vikhr-M",
+                                "quantity": 12
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "12x9A4172, 40xS-8OFP, 4xIgla",
+                        "name": "Gun / ATGM"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Igla",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "FAB-500",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "S-13",
+                                "quantity": 10
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "10xS-13, 2xFAB-500, 4xIgla",
+                        "name": "Gun / Bombs / Rockets / Fox 2"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "ka-50.png"
-         },
-         "Mi-24P": {
-            "name": "Mi-24P",
-            "era": ["Mid Cold War"],
-            "label": "Mi-24P Hind",
-            "shortLabel": "Mi24",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "S-8KOM",
-                        "quantity": 40
-                     },
-                     {
-                        "name": "9M114 ATGM",
-                        "quantity": 8
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "2xB8V20 (S-8KOM)+8xATGM 9M114",
-                  "name": "Gun / ATGM / Rockets"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "S-24B",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "9M114 ATGM",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "Strike"
-                  ],
-                  "code": "4xS-24B+4xATGM 9M114",
-                  "name": "Gun / ATGM / Rockets"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "GUV-1 Grenade Launcher",
-                        "quantity": 4
-                     },
-                     {
-                        "name": "9M114 ATGM",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "4xGUV-1 AP30+4xATGM 9M114",
-                  "name": "Gun / ATGM / Grenade Launcher"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "ka-50.png"
+            },
+            "Mi-24P": {
+                "name": "Mi-24P",
+                "coalition": "Red",
+                "era": "Mid Cold War",
+                "label": "Mi-24P Hind",
+                "shortLabel": "Mi24",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "S-8KOM",
+                                "quantity": 40
+                            },
+                            {
+                                "name": "9M114 ATGM",
+                                "quantity": 8
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "2xB8V20 (S-8KOM)+8xATGM 9M114",
+                        "name": "Gun / ATGM / Rockets"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "S-24B",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "9M114 ATGM",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "Strike"
+                        ],
+                        "code": "4xS-24B+4xATGM 9M114",
+                        "name": "Gun / ATGM / Rockets"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "GUV-1 Grenade Launcher",
+                                "quantity": 4
+                            },
+                            {
+                                "name": "9M114 ATGM",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "4xGUV-1 AP30+4xATGM 9M114",
+                        "name": "Gun / ATGM / Grenade Launcher"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mi-24.png"
-         },
-         "SA342L": {
-            "name": "SA342L",
-            "era": ["Mid Cold War"],
-            "label": "SA342L Gazelle",
-            "shortLabel": "342",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "20mm Cannon",
-                        "quantity": 1
-                     },
-                     {
-                        "name": "SNEB68",
-                        "quantity": 8
-                     }
-                  ],
-                  "roles": [
-                     "Recon"
-                  ],
-                  "code": "M621, 8xSNEB68 EAP",
-                  "name": "Gun / ATGM / Rockets"
-               }
-            ],
-            "filename": "sa-342.png"
-         },
-         "SA342M": {
-            "name": "SA342M",
-            "era": ["Mid Cold War"],
-            "label": "SA342M Gazelle",
-            "shortLabel": "342",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "HOT3",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "HOT3x4",
-                  "name": "ATGM"
-               }
-            ],
-            "filename": "sa-342.png"
-         },
-         "SA342Mistral": {
-            "name": "SA342Mistral",
-            "era": ["Mid Cold War"],
-            "label": "SA342Mistral Gazelle",
-            "shortLabel": "342",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Mistral",
-                        "quantity": 4
-                     }
-                  ],
-                  "roles": [
-                     "CAP"
-                  ],
-                  "code": "Mistral x 4",
-                  "name": "Fox 2"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mi-24.png"
+            },
+            "SA342L": {
+                "name": "SA342L",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "SA342L Gazelle",
+                "shortLabel": "342",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "20mm Cannon",
+                                "quantity": 1
+                            },
+                            {
+                                "name": "SNEB68",
+                                "quantity": 8
+                            }
+                        ],
+                        "roles": [
+                            "Recon"
+                        ],
+                        "code": "M621, 8xSNEB68 EAP",
+                        "name": "Gun / ATGM / Rockets"
+                    }
+                ],
+                "filename": "sa-342.png"
+            },
+            "SA342M": {
+                "name": "SA342M",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "SA342M Gazelle",
+                "shortLabel": "342",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "HOT3",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "HOT3x4",
+                        "name": "ATGM"
+                    }
+                ],
+                "filename": "sa-342.png"
+            },
+            "SA342Mistral": {
+                "name": "SA342Mistral",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "SA342Mistral Gazelle",
+                "shortLabel": "342",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Mistral",
+                                "quantity": 4
+                            }
+                        ],
+                        "roles": [
+                            "CAP"
+                        ],
+                        "code": "Mistral x 4",
+                        "name": "Fox 2"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "sa-342.png"
-         },
-         "AH-1W": {
-            "name": "AH-1W",
-            "era": ["Mid Cold War"],
-            "label": "AH-1W Cobra",
-            "shortLabel": "AH1",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "BGM-71 TOW",
-                        "quantity": 8
-                     },
-                     {
-                        "name": "Hydra-70 WP",
-                        "quantity": 38
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "8xBGM-71, 38xHYDRA-70 WP",
-                  "name": "TOW / Hydra"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "Hydra-70",
-                        "quantity": 76
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "76xHYDRA-70",
-                  "name": "Hydra"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "sa-342.png"
+            },
+            "AH-1W": {
+                "name": "AH-1W",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "AH-1W Cobra",
+                "shortLabel": "AH1",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "BGM-71 TOW",
+                                "quantity": 8
+                            },
+                            {
+                                "name": "Hydra-70 WP",
+                                "quantity": 38
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "8xBGM-71, 38xHYDRA-70 WP",
+                        "name": "TOW / Hydra"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "Hydra-70",
+                                "quantity": 76
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "76xHYDRA-70",
+                        "name": "Hydra"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "ah-1.png"
-         },
-         "Mi-26": {
-            "name": "Mi-26",
-            "era": ["Late Cold War"],
-            "label": "Mi-26 Halo",
-            "shortLabel": "M26",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "ah-1.png"
+            },
+            "Mi-26": {
+                "name": "Mi-26",
+                "coalition": "Red",
+                "era": "Late Cold War",
+                "label": "Mi-26 Halo",
+                "shortLabel": "M26",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mi-26.png"
-         },
-         "Mi-28N": {
-            "name": "Mi-28N",
-            "era": ["Modern"],
-            "label": "Mi-28N Havoc",
-            "shortLabel": "M28",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "9M114 Shturm",
-                        "quantity": 16
-                     },
-                     {
-                        "name": "S-8",
-                        "quantity": 40
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "16x9M114, 40xS-8",
-                  "name": "ATGM / S-8"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mi-26.png"
+            },
+            "Mi-28N": {
+                "name": "Mi-28N",
+                "coalition": "Red",
+                "era": "Modern",
+                "label": "Mi-28N Havoc",
+                "shortLabel": "M28",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "9M114 Shturm",
+                                "quantity": 16
+                            },
+                            {
+                                "name": "S-8",
+                                "quantity": 40
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "16x9M114, 40xS-8",
+                        "name": "ATGM / S-8"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     ""
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mi-28.png"
-         },
-         "Mi-8MT": {
-            "name": "Mi-8MT",
-            "era": ["Mid Cold War"],
-            "label": "Mi-8MT Hip",
-            "shortLabel": "Mi8",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "UPK",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "B8",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "2 x UPK +2 x B8",
-                  "name": "Rockets / Gunpods"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            ""
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mi-28.png"
+            },
+            "Mi-8MT": {
+                "name": "Mi-8MT",
+                "coalition": "Red",
+                "era": "Mid Cold War",
+                "label": "Mi-8MT Hip",
+                "shortLabel": "Mi8",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "UPK",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "B8",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "2 x UPK +2 x B8",
+                        "name": "Rockets / Gunpods"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "mi-8.png"
-         },
-         "SH-60B": {
-            "name": "SH-60B",
-            "era": ["Mid Cold War"],
-            "label": "SH-60B Seahawk",
-            "shortLabel": "S60",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "AGM-119 ASM",
-                        "quantity": 1
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "AGM-119",
-                  "name": "ASM"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "mi-8.png"
+            },
+            "SH-60B": {
+                "name": "SH-60B",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "SH-60B Seahawk",
+                "shortLabel": "S60",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "AGM-119 ASM",
+                                "quantity": 1
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "AGM-119",
+                        "name": "ASM"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "uh-60.png"
-         },
-         "UH-60A": {
-            "name": "UH-60A",
-            "era": ["Mid Cold War"],
-            "label": "UH-60A Blackhawk",
-            "shortLabel": "U60",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "uh-60.png"
+            },
+            "UH-60A": {
+                "name": "UH-60A",
+                "coalition": "Blue",
+                "era": "Mid Cold War",
+                "label": "UH-60A Blackhawk",
+                "shortLabel": "U60",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "uh-60.png"
-         },
-         "UH-1H": {
-            "name": "UH-1H",
-            "era": ["Early Cold War"],
-            "label": "UH-1H Huey",
-            "shortLabel": "UH1",
-            "loadouts": [
-               {
-                  "fuel": 1,
-                  "items": [
-                     {
-                        "name": "M134 Minigun",
-                        "quantity": 2
-                     },
-                     {
-                        "name": "XM-158",
-                        "quantity": 2
-                     }
-                  ],
-                  "roles": [
-                     "CAS"
-                  ],
-                  "code": "M134 Minigun*2, XM158*2",
-                  "name": "Miniguns / XM158"
-               },
-               {
-                  "fuel": 1,
-                  "items": [
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "uh-60.png"
+            },
+            "UH-1H": {
+                "name": "UH-1H",
+                "coalition": "Blue",
+                "era": "Early Cold War",
+                "label": "UH-1H Huey",
+                "shortLabel": "UH1",
+                "loadouts": [
+                    {
+                        "fuel": 1,
+                        "items": [
+                            {
+                                "name": "M134 Minigun",
+                                "quantity": 2
+                            },
+                            {
+                                "name": "XM-158",
+                                "quantity": 2
+                            }
+                        ],
+                        "roles": [
+                            "CAS"
+                        ],
+                        "code": "M134 Minigun*2, XM158*2",
+                        "name": "Miniguns / XM158"
+                    },
+                    {
+                        "fuel": 1,
+                        "items": [
 
-                  ],
-                  "roles": [
-                     "Transport"
-                  ],
-                  "code": "",
-                  "name": "Empty Loadout"
-               }
-            ],
-            "filename": "uh-1.png"
-         }
-      }
-   }
+                        ],
+                        "roles": [
+                            "Transport"
+                        ],
+                        "code": "",
+                        "name": "Empty Loadout"
+                    }
+                ],
+                "filename": "uh-1.png"
+            }
+        }
+    }
 }
 
 export var helicopterDatabase = new HelicopterDatabase();

--- a/client/src/units/navyunitdatabase.ts
+++ b/client/src/units/navyunitdatabase.ts
@@ -6,10 +6,9 @@ export class NavyUnitDatabase extends UnitDatabase {
         this.blueprints = {
             "052B DDG-168 Guangzhou": {
                 "name": "052B DDG-168 Guangzhou",
+                "coalition": "Red",
                 "type": "Destroyer",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "052B DDG-168 Guangzhou",
                 "shortLabel": "052B DDG-168 Guangzhou",
                 "range": "Short",
@@ -17,10 +16,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "052C DDG-171 Haikou": {
                 "name": "052C DDG-171 Haikou",
+                "coalition": "Red",
                 "type": "Destroyer",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "052C DDG-171 Haikou",
                 "shortLabel": "052C DDG-171 Haikou",
                 "range": "Short",
@@ -28,10 +26,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "054A FFG-538 Yantai": {
                 "name": "054A FFG-538 Yantai",
+                "coalition": "Red",
                 "type": "Frigate",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "054A FFG-538 Yantai",
                 "shortLabel": "054A FFG-538 Yantai",
                 "range": "Medium",
@@ -39,10 +36,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Type 071": {
                 "name": "Type 071",
+                "coalition": "Red",
                 "type": "Transport",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "Type 071",
                 "shortLabel": "Type 071",
                 "range": "",
@@ -50,10 +46,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Type 093": {
                 "name": "Type 093",
+                "coalition": "Red",
                 "type": "Submarine",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "Type 093",
                 "shortLabel": "Type 093",
                 "range": "",
@@ -61,10 +56,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Akizuki": {
                 "name": "Akizuki",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "Akizuki",
                 "shortLabel": "Akizuki",
                 "range": "",
@@ -72,10 +66,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "ARA Santa Fe S-21": {
                 "name": "ARA Santa Fe S-21",
+                "coalition": "",
                 "type": "Submarine",
-                "era": [
-                    "Early Cold War"
-                ],
+                "era": "Early Cold War",
                 "label": "ARA Santa Fe S-21",
                 "shortLabel": "ARA Santa Fe S-21",
                 "range": "",
@@ -83,10 +76,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "ARA Vienticinco de Mayo": {
                 "name": "ARA Vienticinco de Mayo",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "ARA Vienticinco de Mayo",
                 "shortLabel": "ARA Vienticinco de Mayo",
                 "range": "",
@@ -94,10 +86,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Admiral Kuznetsov": {
                 "name": "Admiral Kuznetsov",
+                "coalition": "Red",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Admiral Kuznetsov",
                 "shortLabel": "Admiral Kuznetsov",
                 "range": "Medium",
@@ -105,10 +96,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Albatros (Grisha-5)": {
                 "name": "Albatros (Grisha-5)",
+                "coalition": "Red",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Early Cold War"
-                ],
+                "era": "Early Cold War",
                 "label": "Albatros (Grisha-5)",
                 "shortLabel": "Albatros (Grisha-5)",
                 "range": "",
@@ -116,10 +106,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Almirante Condell PFG-06": {
                 "name": "Almirante Condell PFG-06",
+                "coalition": "Blue",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "Almirante Condell PFG-06",
                 "shortLabel": "Almirante Condell PFG-06",
                 "range": "",
@@ -127,10 +116,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Almirante lynch PFG-07": {
                 "name": "Almirante lynch PFG-07",
+                "coalition": "Red",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "Almirante lynch PFG-07",
                 "shortLabel": "Almirante lynch PFG-07",
                 "range": "",
@@ -138,10 +126,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Boat Armed Hi-Speed": {
                 "name": "Boat Armed Hi-Speed",
+                "coalition": "",
                 "type": "Fast Attack Craft",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "Boat Armed Hi-Speed",
                 "shortLabel": "Boat Armed Hi-Speed",
                 "range": "",
@@ -149,10 +136,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Boat LCVP Higgins": {
                 "name": "Boat LCVP Higgins",
+                "coalition": "",
                 "type": "Landing Craft",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "Boat LCVP Higgins",
                 "shortLabel": "Boat LCVP Higgins",
                 "range": "",
@@ -160,10 +146,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Boat Schnellboot type S130": {
                 "name": "Boat Schnellboot type S130",
+                "coalition": "",
                 "type": "Fast Attack Craft",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "Boat Schnellboot type S130",
                 "shortLabel": "Boat Schnellboot type S130",
                 "range": "",
@@ -171,10 +156,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Bulker Handy Wind": {
                 "name": "Bulker Handy Wind",
+                "coalition": "Blue",
                 "type": "Cargoship",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Bulker Handy Wind",
                 "shortLabel": "Bulker Handy Wind",
                 "range": "",
@@ -182,10 +166,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CV Admiral Kuznetsov(2017)": {
                 "name": "CV 1143.5 Admiral Kuznetsov(2017)",
+                "coalition": "Red",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "CV Admiral Kuznetsov(2017)",
                 "shortLabel": "Admiral Kuznetsov(2017)",
                 "range": "Medium",
@@ -193,10 +176,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CV-59 Forrestal": {
                 "name": "CV-59 Forrestal",
+                "coalition": "Blue",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Early Cold War"
-                ],
+                "era": "Early Cold War",
                 "label": "CV-59 Forrestal",
                 "shortLabel": "CV-59 Forrestal",
                 "range": "Short",
@@ -204,10 +186,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CV6 USS Enterprise": {
                 "name": "CV6 USS Enterprise -The Grey Ghost-",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "CV6 USS Enterprise Grey Ghost",
                 "shortLabel": "CV6 USS Enterprise",
                 "range": "",
@@ -215,10 +196,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CVN-71 Theodore Roosevelt": {
                 "name": "CVN-71 Theodore Roosevelt",
+                "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "CVN-71 Theodore Roosevelt",
                 "shortLabel": "CVN-71 Theodore Roosevelt",
                 "range": "Short",
@@ -226,10 +206,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CVN-72 Abraham Lincoln": {
                 "name": "CVN-72 Abraham Lincoln",
+                "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "CVN-72 Abraham Lincoln",
                 "shortLabel": "CVN-72 Abraham Lincoln",
                 "range": "Short",
@@ -237,10 +216,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CVN-73 George Washington": {
                 "name": "CVN-73 George Washington",
+                "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "CVN-73 George Washington",
                 "shortLabel": "CVN-73 George Washington",
                 "range": "Medium",
@@ -248,10 +226,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CVN-74 John C. Stennis": {
                 "name": "CVN-74 John C. Stennis",
+                "coalition": "Blue",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "CVN-74 John C. Stennis",
                 "shortLabel": "CVN-74 John C. Stennis",
                 "range": "Medium",
@@ -259,10 +236,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "CVN-75 Harry S. Truman": {
                 "name": "CVN-75 Harry S. Truman",
+                "coalition": "Blue",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "CVN-75 Harry S. Truman",
                 "shortLabel": "CVN-75 Harry S. Truman",
                 "range": "Medium",
@@ -270,10 +246,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "HMS Leeds Castle (P-258)": {
                 "name": "Castle Class",
+                "coalition": "Blue",
                 "type": "Patrol",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "HMS Leeds Castle (P-258)",
                 "shortLabel": "HMS Leeds Castle (P-258)",
                 "range": "",
@@ -281,10 +256,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DDG Arleigh Burke lla": {
                 "name": "DDG Arleigh Burke lla",
+                "coalition": "Blue",
                 "type": "Destroyer",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "DDG Arleigh Burke lla",
                 "shortLabel": "DDG Arleigh Burke",
                 "range": "Medium",
@@ -292,10 +266,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Admiral Hipper": {
                 "name": "DKM Admiral Hipper",
+                "coalition": "",
                 "type": "Cruiser",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Admiral Hipper",
                 "shortLabel": "DKM Admiral Hipper",
                 "range": "",
@@ -303,10 +276,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Admiral Scheer": {
                 "name": "DKM Admiral Scheer",
+                "coalition": "",
                 "type": "Cruiser",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Admiral Scheer",
                 "shortLabel": "DKM Admiral Scheer",
                 "range": "",
@@ -314,10 +286,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Blucher": {
                 "name": "DKM Blucher",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Blucher",
                 "shortLabel": "DKM Blucher",
                 "range": "",
@@ -325,10 +296,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Gneisenau": {
                 "name": "DKM Blucher",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Blucher",
                 "shortLabel": "DKM Blucher",
                 "range": "",
@@ -336,10 +306,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Prinz Eugen": {
                 "name": "DKM Prinz Eugen",
+                "coalition": "",
                 "type": "Cruiser",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Prinz Eugen",
                 "shortLabel": "DKM Prinz Eugen",
                 "range": "",
@@ -347,10 +316,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Scharnhorst": {
                 "name": "Scharnhorst",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Scharnhorst",
                 "shortLabel": "DKM Scharnhorst",
                 "range": "",
@@ -358,10 +326,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Tirpiz": {
                 "name": "DKM Tirpiz",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Tirpiz",
                 "shortLabel": "DKM Tirpiz",
                 "range": "",
@@ -369,10 +336,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "DKM Z39": {
                 "name": "DKM Z39",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "DKM Z39",
                 "shortLabel": "DKM Z39",
                 "range": "",
@@ -380,10 +346,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Dry cargo ship Ivanov": {
                 "name": "Dry cargo ship Ivanov",
+                "coalition": "Red",
                 "type": "Cargoship",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Dry cargo ship Ivanov",
                 "shortLabel": "Dry cargo ship Ivanov",
                 "range": "",
@@ -391,10 +356,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Dry cargo ship Yakushev": {
                 "name": "Dry cargo ship Yakushev",
+                "coalition": "Red",
                 "type": "Cargoship",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Dry cargo ship Yakushev",
                 "shortLabel": "Dry cargo ship Yakushev",
                 "range": "",
@@ -402,10 +366,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Elnya tanker": {
                 "name": "Elnya tanker",
+                "coalition": "Red",
                 "type": "Tanker",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Elnya tanker",
                 "shortLabel": "Elnya tanker",
                 "range": "",
@@ -413,10 +376,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "FAC La Combattante lla": {
                 "name": "FAC La Combattante lla",
+                "coalition": "Blue",
                 "type": "Fast Attack Craft",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "FAC La Combattante lla",
                 "shortLabel": "FAC La Combattante",
                 "range": "",
@@ -424,10 +386,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Fletcher-Class destroyer": {
                 "name": "Fletcher-Class destroyer",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "Fletcher-Class destroyer",
                 "shortLabel": "Fletcher-Class destroyer",
                 "range": "",
@@ -435,10 +396,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "HMS Achilles (F12)": {
                 "name": "HMS Achilles (F12)",
+                "coalition": "Blue",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "HMS Achilles (F12)",
                 "shortLabel": "HMS Achilles",
                 "range": "",
@@ -446,10 +406,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "HMS Andromeda (F57)": {
                 "name": "HMS Andromeda (F57)",
+                "coalition": "Blue",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "HMS Andromeda (F57)",
                 "shortLabel": "HMS Andromeda",
                 "range": "",
@@ -457,10 +416,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "HMS Ariadne (F72)": {
                 "name": "HMS Ariadne (F72)",
+                "coalition": "Blue",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "HMS Ariadne (F72)",
                 "shortLabel": "HMS Ariadne",
                 "range": "",
@@ -468,10 +426,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "HMS Invincible (R05)": {
                 "name": "HMS Invincible (R05)",
+                "coalition": "Blue",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "HMS Invincible (R05)",
                 "shortLabel": "HMS Invincible",
                 "range": "",
@@ -479,10 +436,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Harbor Tug": {
                 "name": "Harbor Tug",
+                "coalition": "",
                 "type": "Tug",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "Harbor Tug",
                 "shortLabel": "Harbor Tug",
                 "range": "",
@@ -490,10 +446,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Improved Kilo": {
                 "name": "Improved Kilo",
+                "coalition": "Red",
                 "type": "Submarine",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Project 636 Varshavyanka",
                 "shortLabel": "Varshavyanka",
                 "range": "Medium",
@@ -501,10 +456,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Kilo": {
                 "name": "Kilo",
+                "coalition": "Red",
                 "type": "Submarine",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Project 636 Varshavyanka Basic",
                 "shortLabel": "Varshavyanka Basic",
                 "range": "Medium",
@@ -512,10 +466,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "LHA-1 Tarawa": {
                 "name": "LHA-1 Tarawa",
+                "coalition": "Blue",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "LHA-1 Tarawa",
                 "shortLabel": "LHA-1 Tarawa",
                 "range": "Short",
@@ -523,10 +476,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "LS Ropucha": {
                 "name": "LS Ropucha",
+                "coalition": "Blue",
                 "type": "Landing Craft",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "LS Ropucha",
                 "shortLabel": "LS Ropucha",
                 "range": "",
@@ -534,10 +486,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "LST Mk2": {
                 "name": "LST Mk2",
+                "coalition": "",
                 "type": "Transport",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "LST Mk2",
                 "shortLabel": "LST Mk2",
                 "range": "",
@@ -545,10 +496,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Molniya (Tarantul-3)": {
                 "name": "Molniya (Tarantul-3)",
+                "coalition": "",
                 "type": "Fast Attack Craft",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Molniya (Tarantul-3)",
                 "shortLabel": "Molniya (Tarantul-3)",
                 "range": "Short",
@@ -556,10 +506,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Moscow": {
                 "name": "Moscow",
+                "coalition": "Red",
                 "type": "Cruiser",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Moscow",
                 "shortLabel": "Moscow",
                 "range": "Medium",
@@ -567,10 +516,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Neustrashimy": {
                 "name": "Neustrashimy",
+                "coalition": "Red",
                 "type": "Frigate",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Neustrashimy",
                 "shortLabel": "Neustrashimy",
                 "range": "Short",
@@ -578,10 +526,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Oliver H. Perry": {
                 "name": "Oliver H. Perry",
+                "coalition": "Blue",
                 "type": "Frigate",
-                "era": [
-                    "Mid Cold War"
-                ],
+                "era": "Mid Cold War",
                 "label": "Oliver H. Perry",
                 "shortLabel": "Oliver H. Perry",
                 "range": "Medium",
@@ -589,10 +536,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Pyotr Velikiy": {
                 "name": "Pyotr Velikiy",
+                "coalition": "Red",
                 "type": "Cruiser",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Pyotr Velikiy",
                 "shortLabel": "Pyotr Velikiy",
                 "range": "Medium",
@@ -600,10 +546,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Rezky (Krivak-2)": {
                 "name": "Rezky (Krivak-2)",
+                "coalition": "Red",
                 "type": "Frigate",
-                "era": [
-                    "Early Cold War"
-                ],
+                "era": "Early Cold War",
                 "label": "Rezky (Krivak-2)",
                 "shortLabel": "Rezky",
                 "range": "Short",
@@ -611,10 +556,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Supply Ship MV Tilde": {
                 "name": "Supply Ship MV Tilde",
+                "coalition": "Blue",
                 "type": "Transport",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Supply Ship MV Tilde",
                 "shortLabel": "Supply Ship MV Tilde",
                 "range": "",
@@ -622,10 +566,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Tanker Seawise Giant": {
                 "name": "Tanker Seawise Giant",
+                "coalition": "Blue",
                 "type": "Tanker",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Tanker Seawise Giant",
                 "shortLabel": "Tanker Seawise Giant",
                 "range": "",
@@ -633,10 +576,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Ticonderoga": {
                 "name": "Ticonderoga",
+                "coalition": "Blue",
                 "type": "Cruiser",
-                "era": [
-                    "Late Cold War"
-                ],
+                "era": "Late Cold War",
                 "label": "Ticonderoga",
                 "shortLabel": "Ticonderoga",
                 "range": "Medium",
@@ -644,10 +586,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "U-boat VIIC U-flak": {
                 "name": "U-boat VIIC U-flak",
+                "coalition": "",
                 "type": "Submarine",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "U-boat VIIC U-flak",
                 "shortLabel": "U-boat VIIC U-flak",
                 "range": "",
@@ -655,10 +596,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Bell DD-587": {
                 "name": "USS Bell DD-587",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Bell DD-587",
                 "shortLabel": "USS Bell DD-587",
                 "range": "",
@@ -666,10 +606,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Cassin Young": {
                 "name": "USS Cassin Young",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Cassin Young",
                 "shortLabel": "USS Cassin Young",
                 "range": "",
@@ -677,10 +616,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Cotten DD-669": {
                 "name": "USS Cotten DD-669",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Cotten DD-669",
                 "shortLabel": "USS Cotten",
                 "range": "",
@@ -688,10 +626,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Enterprise": {
                 "name": "USS Enterprise",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "CV-6 USS Enterprise",
                 "shortLabel": "USS Enterprise",
                 "range": "",
@@ -699,10 +636,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Fletcher": {
                 "name": "USS Fletcher",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Fletcher",
                 "shortLabel": "USS Fletcher",
                 "range": "",
@@ -710,10 +646,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Franklin -Big Ben-": {
                 "name": "USS Franklin -Big Ben-",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Franklin -Big Ben-",
                 "shortLabel": "USS Franklin",
                 "range": "",
@@ -721,10 +656,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Gregory DD-802": {
                 "name": "USS Gregory DD-802",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Gregory DD-802",
                 "shortLabel": "USS Gregory",
                 "range": "",
@@ -732,10 +666,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Hopewell DD-681": {
                 "name": "USS Hopewell DD-681",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Hopewell DD-681",
                 "shortLabel": "USS Hopewell",
                 "range": "",
@@ -743,10 +676,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Hornet (CV-8)": {
                 "name": "USS Hornet (CV-8)",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Hornet (CV-8)",
                 "shortLabel": "USS Hornet (CV-8)",
                 "range": "",
@@ -754,10 +686,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Illinois BB-65": {
                 "name": "USS Illinois BB-65",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Illinois BB-65",
                 "shortLabel": "USS Illinois",
                 "range": "",
@@ -765,10 +696,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Iowa": {
                 "name": "USS Iowa",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Iowa",
                 "shortLabel": "USS Iowa",
                 "range": "",
@@ -776,10 +706,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Johnson DD-557": {
                 "name": "USS Johnson DD-557",
+                "coalition": "",
                 "type": "Destoryer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Johnson DD-557",
                 "shortLabel": "USS Johnson",
                 "range": "",
@@ -787,10 +716,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Kentucky BB-66": {
                 "name": "USS Kentucky BB-66",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Kentucky BB-66",
                 "shortLabel": "USS Kentucky",
                 "range": "",
@@ -798,10 +726,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS La Vallette DD-448": {
                 "name": "USS La Vallette DD-448",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS La Vallette DD-448",
                 "shortLabel": "USS La Vallette",
                 "range": "",
@@ -809,10 +736,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Missouri": {
                 "name": "USS Missouri",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Missouri",
                 "shortLabel": "USS Missouri",
                 "range": "",
@@ -820,10 +746,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS New Jersey": {
                 "name": "USS New Jersey",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS New Jersey",
                 "shortLabel": "USS New Jersey",
                 "range": "",
@@ -831,10 +756,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Radford DD-446": {
                 "name": "USS Radford DD-446",
+                "coalition": "",
                 "type": "Destroyer",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Radford DD-446",
                 "shortLabel": "USS Radford",
                 "range": "",
@@ -842,10 +766,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Samuel Chase": {
                 "name": "USS Samuel Chase",
+                "coalition": "",
                 "type": "Transport",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Samuel Chase",
                 "shortLabel": "USS Samuel Chase",
                 "range": "",
@@ -853,10 +776,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "USS Winsconsin": {
                 "name": "Winsconsin",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "USS Winsconsin",
                 "shortLabel": "USS Winsconsin",
                 "range": "",
@@ -864,10 +786,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "WW II USS Intrepid CV-11": {
                 "name": "WW II USS Intrepid CV-11",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "WW II USS Intrepid CV-11",
                 "shortLabel": "USS Intrepid",
                 "range": "",
@@ -875,10 +796,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "WWII Japanese Battleship Musashi": {
                 "name": "WWII Japanese Battleship Musashi",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "WWII Japanese Battleship Musashi",
                 "shortLabel": "Battleship Musashi",
                 "range": "",
@@ -886,10 +806,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "WWII Japanese Battleship Yamato": {
                 "name": "WWII Japanese Battleship Yamato",
+                "coalition": "",
                 "type": "Battleship",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "WWII Japanese Battleship Yamato",
                 "shortLabel": "Battleship Yamato",
                 "range": "",
@@ -897,10 +816,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "WWII USS Yorktown CV-5": {
                 "name": "WWII USS Yorktown CV-5",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "WWII USS Yorktown CV-5",
                 "shortLabel": "USS Yorktown",
                 "range": "",
@@ -908,10 +826,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "WWII USS Hornet CV-8": {
                 "name": "WWII USS Hornet CV-8",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "WWII USS Hornet CV-8",
                 "shortLabel": "USS Hornet",
                 "range": "",
@@ -919,10 +836,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "ZUIKAKU": {
                 "name": "ZUIKAKU",
+                "coalition": "",
                 "type": "Aircraft Carrier",
-                "era": [
-                    "WW2"
-                ],
+                "era": "WW2",
                 "label": "ZUIKAKU",
                 "shortLabel": "ZUIKAKU",
                 "range": "",
@@ -930,10 +846,9 @@ export class NavyUnitDatabase extends UnitDatabase {
             },
             "Zwezdny": {
                 "name": "Zwezdny",
+                "coalition": "",
                 "type": "Civilian Boat",
-                "era": [
-                    "Modern"
-                ],
+                "era": "Modern",
                 "label": "Zwezdny",
                 "shortLabel": "Zwezdny",
                 "range": "",

--- a/client/src/units/navyunitdatabase.ts
+++ b/client/src/units/navyunitdatabase.ts
@@ -4,38 +4,38 @@ export class NavyUnitDatabase extends UnitDatabase {
     constructor() {
         super();
         this.blueprints = {
-            "052B DDG-168 Guangzhou": {
-                "name": "052B DDG-168 Guangzhou",
+            "Type_052B": {
+                "name": "Type_052B",
                 "coalition": "Red",
                 "type": "Destroyer",
                 "era": "Modern",
                 "label": "052B DDG-168 Guangzhou",
-                "shortLabel": "052B DDG-168 Guangzhou",
+                "shortLabel": "Type 52B",
                 "range": "Short",
                 "filename": ""
             },
-            "052C DDG-171 Haikou": {
-                "name": "052C DDG-171 Haikou",
+            "Type_052C": {
+                "name": "Type_052C",
                 "coalition": "Red",
                 "type": "Destroyer",
                 "era": "Modern",
                 "label": "052C DDG-171 Haikou",
-                "shortLabel": "052C DDG-171 Haikou",
+                "shortLabel": "Type 52C",
                 "range": "Short",
                 "filename": ""
             },
-            "054A FFG-538 Yantai": {
-                "name": "054A FFG-538 Yantai",
+            "Type_054A": {
+                "name": "",
                 "coalition": "Red",
                 "type": "Frigate",
                 "era": "Modern",
                 "label": "054A FFG-538 Yantai",
-                "shortLabel": "054A FFG-538 Yantai",
+                "shortLabel": "Type 54A",
                 "range": "Medium",
                 "filename": ""
             },
-            "Type 071": {
-                "name": "Type 071",
+            "Type_071": {
+                "name": "Type_071",
                 "coalition": "Red",
                 "type": "Transport",
                 "era": "Modern",
@@ -44,8 +44,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Type 093": {
-                "name": "Type 093",
+            "Type_093": {
+                "name": "Type_093",
                 "coalition": "Red",
                 "type": "Submarine",
                 "era": "Modern",
@@ -54,18 +54,18 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "ARA Santa Fe S-21": {
-                "name": "ARA Santa Fe S-21",
+            "santafe": {
+                "name": "santafe",
                 "coalition": "",
                 "type": "Submarine",
                 "era": "Early Cold War",
                 "label": "ARA Santa Fe S-21",
-                "shortLabel": "ARA Santa Fe S-21",
+                "shortLabel": "ARA Santa",
                 "range": "",
                 "filename": ""
             },
-            "ARA Vienticinco de Mayo": {
-                "name": "ARA Vienticinco de Mayo",
+            "ara_vdm": {
+                "name": "ara_vdm",
                 "coalition": "",
                 "type": "Aircraft Carrier",
                 "era": "Mid Cold War",
@@ -74,8 +74,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Admiral Kuznetsov": {
-                "name": "Admiral Kuznetsov",
+            "kuznecow": {
+                "name": "kuznecow",
                 "coalition": "Red",
                 "type": "Aircraft Carrier",
                 "era": "Late Cold War",
@@ -84,33 +84,23 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "Albatros (Grisha-5)": {
-                "name": "Albatros (Grisha-5)",
+            "albatros": {
+                "name": "albatros",
                 "coalition": "Red",
                 "type": "Aircraft Carrier",
                 "era": "Early Cold War",
                 "label": "Albatros (Grisha-5)",
-                "shortLabel": "Albatros (Grisha-5)",
+                "shortLabel": "Albatros",
                 "range": "",
                 "filename": ""
             },
-            "Almirante Condell PFG-06": {
-                "name": "Almirante Condell PFG-06",
-                "coalition": "Blue",
+            "leander-gun-condell": {
+                "name": "leander-gun-condell",
+                "coalition": "",
                 "type": "Frigate",
                 "era": "Mid Cold War",
                 "label": "Almirante Condell PFG-06",
-                "shortLabel": "Almirante Condell PFG-06",
-                "range": "",
-                "filename": ""
-            },
-            "Almirante lynch PFG-07": {
-                "name": "Almirante lynch PFG-07",
-                "coalition": "Red",
-                "type": "Frigate",
-                "era": "Mid Cold War",
-                "label": "Almirante lynch PFG-07",
-                "shortLabel": "Almirante lynch PFG-07",
+                "shortLabel": "Almirante Condell",
                 "range": "",
                 "filename": ""
             },
@@ -124,28 +114,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Boat LCVP Higgins": {
-                "name": "Boat LCVP Higgins",
-                "coalition": "",
-                "type": "Landing Craft",
-                "era": "WW2",
-                "label": "Boat LCVP Higgins",
-                "shortLabel": "Boat LCVP Higgins",
-                "range": "",
-                "filename": ""
-            },
-            "Boat Schnellboot type S130": {
-                "name": "Boat Schnellboot type S130",
-                "coalition": "",
-                "type": "Fast Attack Craft",
-                "era": "WW2",
-                "label": "Boat Schnellboot type S130",
-                "shortLabel": "Boat Schnellboot type S130",
-                "range": "",
-                "filename": ""
-            },
-            "Bulker Handy Wind": {
-                "name": "Bulker Handy Wind",
+            "HandyWind": {
+                "name": "HandyWind",
                 "coalition": "Blue",
                 "type": "Cargoship",
                 "era": "Late Cold War",
@@ -154,8 +124,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "CV 1143.5 Admiral Kuznetsov(2017)": {
-                "name": "CV 1143.5 Admiral Kuznetsov(2017)",
+            "CV_1143_5": {
+                "name": "CV_1143_5",
                 "coalition": "Red",
                 "type": "Aircraft Carrier",
                 "era": "Modern",
@@ -164,68 +134,68 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "CV-59 Forrestal": {
-                "name": "CV-59 Forrestal",
+            "CV_59": {
+                "name": "CV_59",
                 "coalition": "Blue",
                 "type": "Aircraft Carrier",
                 "era": "Early Cold War",
                 "label": "CV-59 Forrestal",
-                "shortLabel": "CV-59 Forrestal",
+                "shortLabel": "CV-59",
                 "range": "Short",
                 "filename": ""
             },
-            "CVN-71 Theodore Roosevelt": {
-                "name": "CVN-71 Theodore Roosevelt",
+            "CVN_71": {
+                "name": "CVN_71",
                 "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
                 "era": "Late Cold War",
                 "label": "CVN-71 Theodore Roosevelt",
-                "shortLabel": "CVN-71 Theodore Roosevelt",
+                "shortLabel": "CVN-71",
                 "range": "Short",
                 "filename": ""
             },
-            "CVN-72 Abraham Lincoln": {
-                "name": "CVN-72 Abraham Lincoln",
+            "CVN_72": {
+                "name": "CVN_72",
                 "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
                 "era": "Late Cold War",
                 "label": "CVN-72 Abraham Lincoln",
-                "shortLabel": "CVN-72 Abraham Lincoln",
+                "shortLabel": "CVN-72",
                 "range": "Short",
                 "filename": ""
             },
-            "CVN-73 George Washington": {
-                "name": "CVN-73 George Washington",
+            "CVN_73": {
+                "name": "CVN_73",
                 "coalition": "Blue",
                 "type": "Super Aircraft Carrier",
                 "era": "Late Cold War",
                 "label": "CVN-73 George Washington",
-                "shortLabel": "CVN-73 George Washington",
+                "shortLabel": "CVN-73",
                 "range": "Medium",
                 "filename": ""
             },
-            "CVN-74 John C. Stennis": {
-                "name": "CVN-74 John C. Stennis",
+            "Stennis": {
+                "name": "Stennis",
                 "coalition": "Blue",
                 "type": "Aircraft Carrier",
                 "era": "Late Cold War",
                 "label": "CVN-74 John C. Stennis",
-                "shortLabel": "CVN-74 John C. Stennis",
+                "shortLabel": "CVN-74",
                 "range": "Medium",
                 "filename": ""
             },
-            "CVN-75 Harry S. Truman": {
-                "name": "CVN-75 Harry S. Truman",
+            "CVN_75": {
+                "name": "CVN_75",
                 "coalition": "Blue",
                 "type": "Aircraft Carrier",
                 "era": "Late Cold War",
                 "label": "CVN-75 Harry S. Truman",
-                "shortLabel": "CVN-75 Harry S. Truman",
+                "shortLabel": "CVN-75",
                 "range": "Medium",
                 "filename": ""
             },
-            "Castle Class": {
-                "name": "Castle Class",
+            "CastleClass_01": {
+                "name": "CastleClass_01",
                 "coalition": "Blue",
                 "type": "Patrol",
                 "era": "Mid Cold War",
@@ -234,8 +204,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "DDG Arleigh Burke lla": {
-                "name": "DDG Arleigh Burke lla",
+            "USS_Arleigh_Burke_IIa": {
+                "name": "USS_Arleigh_Burke_IIa",
                 "coalition": "Blue",
                 "type": "Destroyer",
                 "era": "Late Cold War",
@@ -244,18 +214,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "DKM Z39": {
-                "name": "DKM Z39",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "DKM Z39",
-                "shortLabel": "DKM Z39",
-                "range": "",
-                "filename": ""
-            },
-            "Dry cargo ship Ivanov": {
-                "name": "Dry cargo ship Ivanov",
+            "barge-1": {
+                "name": "barge-1",
                 "coalition": "Red",
                 "type": "Cargoship",
                 "era": "Late Cold War",
@@ -264,8 +224,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Dry cargo ship Yakushev": {
-                "name": "Dry cargo ship Yakushev",
+            "barge-2": {
+                "name": "barge-2",
                 "coalition": "Red",
                 "type": "Cargoship",
                 "era": "Late Cold War",
@@ -274,8 +234,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Elnya tanker": {
-                "name": "Elnya tanker",
+            "elnya": {
+                "name": "elnya",
                 "coalition": "Red",
                 "type": "Tanker",
                 "era": "Late Cold War",
@@ -284,8 +244,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "FAC La Combattante lla": {
-                "name": "FAC La Combattante lla",
+            "La_Combattante_II": {
+                "name": "La_Combattante_II",
                 "coalition": "Blue",
                 "type": "Fast Attack Craft",
                 "era": "Mid Cold War",
@@ -294,18 +254,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Fletcher-Class destroyer": {
-                "name": "Fletcher-Class destroyer",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "Fletcher-Class destroyer",
-                "shortLabel": "Fletcher-Class destroyer",
-                "range": "",
-                "filename": ""
-            },
-            "HMS Achilles (F12)": {
-                "name": "HMS Achilles (F12)",
+            "leander-gun-achilles": {
+                "name": "leander-gun-achilles",
                 "coalition": "Blue",
                 "type": "Frigate",
                 "era": "Mid Cold War",
@@ -314,8 +264,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "HMS Andromeda (F57)": {
-                "name": "HMS Andromeda (F57)",
+            "leander-gun-andromeda": {
+                "name": "leander-gun-andromeda",
                 "coalition": "Blue",
                 "type": "Frigate",
                 "era": "Mid Cold War",
@@ -324,8 +274,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "HMS Ariadne (F72)": {
-                "name": "HMS Ariadne (F72)",
+            "leander-gun-ariadne": {
+                "name": "leander-gun-ariadne",
                 "coalition": "Blue",
                 "type": "Frigate",
                 "era": "Mid Cold War",
@@ -334,8 +284,18 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "HMS Invincible (R05)": {
-                "name": "HMS Invincible (R05)",
+            "leander-gun-lynch": {
+                "name": "leander-gun-lynch",
+                "coalition": "",
+                "type": "Frigate",
+                "era": "Mid Cold War",
+                "label": "CNS Almirante Lynch (PFG-07)",
+                "shortLabel": "CNS Almirante Lynch",
+                "range": "",
+                "filename": ""
+            },
+            "hms_invincible": {
+                "name": "hms_invincible",
                 "coalition": "Blue",
                 "type": "Aircraft Carrier",
                 "era": "Mid Cold War",
@@ -344,8 +304,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Harbor Tug": {
-                "name": "Harbor Tug",
+            "HarborTug": {
+                "name": "HarborTug",
                 "coalition": "",
                 "type": "Tug",
                 "era": "Mid Cold War",
@@ -354,18 +314,18 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Improved Kilo": {
-                "name": "Improved Kilo",
+            "kilo_636": {
+                "name": "kilo_636",
                 "coalition": "Red",
                 "type": "Submarine",
                 "era": "Late Cold War",
-                "label": "Project 636 Varshavyanka",
-                "shortLabel": "Varshavyanka",
+                "label": "Project 636 Varshavyanka Improved",
+                "shortLabel": "Varshavyanka Improved",
                 "range": "Medium",
                 "filename": ""
             },
-            "Kilo": {
-                "name": "Kilo",
+            "kilo": {
+                "name": "kilo",
                 "coalition": "Red",
                 "type": "Submarine",
                 "era": "Late Cold War",
@@ -374,8 +334,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "LHA-1 Tarawa": {
-                "name": "LHA-1 Tarawa",
+            "LHA_Tarawa": {
+                "name": "LHA_Tarawa",
                 "coalition": "Blue",
                 "type": "Aircraft Carrier",
                 "era": "Mid Cold War",
@@ -384,8 +344,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Short",
                 "filename": ""
             },
-            "LS Ropucha": {
-                "name": "LS Ropucha",
+            "BDK-775": {
+                "name": "BDK-775",
                 "coalition": "Blue",
                 "type": "Landing Craft",
                 "era": "Mid Cold War",
@@ -394,28 +354,18 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "LST Mk2": {
-                "name": "LST Mk2",
-                "coalition": "",
-                "type": "Transport",
-                "era": "WW2",
-                "label": "LST Mk2",
-                "shortLabel": "LST Mk2",
-                "range": "",
-                "filename": ""
-            },
-            "Molniya (Tarantul-3)": {
-                "name": "Molniya (Tarantul-3)",
+            "molniya": {
+                "name": "molniya",
                 "coalition": "",
                 "type": "Fast Attack Craft",
                 "era": "Late Cold War",
                 "label": "Molniya (Tarantul-3)",
-                "shortLabel": "Molniya (Tarantul-3)",
+                "shortLabel": "Molniya",
                 "range": "Short",
                 "filename": ""
             },
-            "Moscow": {
-                "name": "Moscow",
+            "moscow": {
+                "name": "moscow",
                 "coalition": "Red",
                 "type": "Cruiser",
                 "era": "Late Cold War",
@@ -424,8 +374,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "Neustrashimy": {
-                "name": "Neustrashimy",
+            "neustrash": {
+                "name": "neustrash",
                 "coalition": "Red",
                 "type": "Frigate",
                 "era": "Late Cold War",
@@ -434,8 +384,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Short",
                 "filename": ""
             },
-            "Oliver H. Perry": {
-                "name": "Oliver H. Perry",
+            "perry": {
+                "name": "perry",
                 "coalition": "Blue",
                 "type": "Frigate",
                 "era": "Mid Cold War",
@@ -444,8 +394,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "Pyotr Velikiy": {
-                "name": "Pyotr Velikiy",
+            "piotr_velikiy": {
+                "name": "piotr_velikiy",
                 "coalition": "Red",
                 "type": "Cruiser",
                 "era": "Late Cold War",
@@ -454,7 +404,7 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "Rezky (Krivak-2)": {
+            "rezky": {
                 "name": "Rezky (Krivak-2)",
                 "coalition": "Red",
                 "type": "Frigate",
@@ -464,28 +414,28 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Short",
                 "filename": ""
             },
-            "Supply Ship MV Tilde": {
-                "name": "Supply Ship MV Tilde",
+            "Ship_Tilde_Supply": {
+                "name": "Ship_Tilde_Supply",
                 "coalition": "Blue",
                 "type": "Transport",
                 "era": "Late Cold War",
                 "label": "Supply Ship MV Tilde",
-                "shortLabel": "Supply Ship MV Tilde",
+                "shortLabel": "Supply Ship Tilde",
                 "range": "",
                 "filename": ""
             },
-            "Tanker Seawise Giant": {
-                "name": "Tanker Seawise Giant",
+            "Seawise_Giant": {
+                "name": "Seawise_Giant",
                 "coalition": "Blue",
                 "type": "Tanker",
                 "era": "Late Cold War",
                 "label": "Tanker Seawise Giant",
-                "shortLabel": "Tanker Seawise Giant",
+                "shortLabel": "Seawise Giant",
                 "range": "",
                 "filename": ""
             },
-            "Ticonderoga": {
-                "name": "Ticonderoga",
+            "TICONDEROG": {
+                "name": "TICONDEROG",
                 "coalition": "Blue",
                 "type": "Cruiser",
                 "era": "Late Cold War",
@@ -494,18 +444,8 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "U-boat VIIC U-flak": {
-                "name": "U-boat VIIC U-flak",
-                "coalition": "",
-                "type": "Submarine",
-                "era": "WW2",
-                "label": "U-boat VIIC U-flak",
-                "shortLabel": "U-boat VIIC U-flak",
-                "range": "",
-                "filename": ""
-            },
-            "Zwezdny": {
-                "name": "Zwezdny",
+            "zwezdny": {
+                "name": "zwezdny",
                 "coalition": "",
                 "type": "Civilian Boat",
                 "era": "Modern",

--- a/client/src/units/navyunitdatabase.ts
+++ b/client/src/units/navyunitdatabase.ts
@@ -54,16 +54,6 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "Akizuki": {
-                "name": "Akizuki",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "Akizuki",
-                "shortLabel": "Akizuki",
-                "range": "",
-                "filename": ""
-            },
             "ARA Santa Fe S-21": {
                 "name": "ARA Santa Fe S-21",
                 "coalition": "",
@@ -164,7 +154,7 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "",
                 "filename": ""
             },
-            "CV Admiral Kuznetsov(2017)": {
+            "CV 1143.5 Admiral Kuznetsov(2017)": {
                 "name": "CV 1143.5 Admiral Kuznetsov(2017)",
                 "coalition": "Red",
                 "type": "Aircraft Carrier",
@@ -182,16 +172,6 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "label": "CV-59 Forrestal",
                 "shortLabel": "CV-59 Forrestal",
                 "range": "Short",
-                "filename": ""
-            },
-            "CV6 USS Enterprise": {
-                "name": "CV6 USS Enterprise -The Grey Ghost-",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "CV6 USS Enterprise Grey Ghost",
-                "shortLabel": "CV6 USS Enterprise",
-                "range": "",
                 "filename": ""
             },
             "CVN-71 Theodore Roosevelt": {
@@ -244,7 +224,7 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "range": "Medium",
                 "filename": ""
             },
-            "HMS Leeds Castle (P-258)": {
+            "Castle Class": {
                 "name": "Castle Class",
                 "coalition": "Blue",
                 "type": "Patrol",
@@ -262,76 +242,6 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "label": "DDG Arleigh Burke lla",
                 "shortLabel": "DDG Arleigh Burke",
                 "range": "Medium",
-                "filename": ""
-            },
-            "DKM Admiral Hipper": {
-                "name": "DKM Admiral Hipper",
-                "coalition": "",
-                "type": "Cruiser",
-                "era": "WW2",
-                "label": "DKM Admiral Hipper",
-                "shortLabel": "DKM Admiral Hipper",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Admiral Scheer": {
-                "name": "DKM Admiral Scheer",
-                "coalition": "",
-                "type": "Cruiser",
-                "era": "WW2",
-                "label": "DKM Admiral Scheer",
-                "shortLabel": "DKM Admiral Scheer",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Blucher": {
-                "name": "DKM Blucher",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "DKM Blucher",
-                "shortLabel": "DKM Blucher",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Gneisenau": {
-                "name": "DKM Blucher",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "DKM Blucher",
-                "shortLabel": "DKM Blucher",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Prinz Eugen": {
-                "name": "DKM Prinz Eugen",
-                "coalition": "",
-                "type": "Cruiser",
-                "era": "WW2",
-                "label": "DKM Prinz Eugen",
-                "shortLabel": "DKM Prinz Eugen",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Scharnhorst": {
-                "name": "Scharnhorst",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "DKM Scharnhorst",
-                "shortLabel": "DKM Scharnhorst",
-                "range": "",
-                "filename": ""
-            },
-            "DKM Tirpiz": {
-                "name": "DKM Tirpiz",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "DKM Tirpiz",
-                "shortLabel": "DKM Tirpiz",
-                "range": "",
                 "filename": ""
             },
             "DKM Z39": {
@@ -591,256 +501,6 @@ export class NavyUnitDatabase extends UnitDatabase {
                 "era": "WW2",
                 "label": "U-boat VIIC U-flak",
                 "shortLabel": "U-boat VIIC U-flak",
-                "range": "",
-                "filename": ""
-            },
-            "USS Bell DD-587": {
-                "name": "USS Bell DD-587",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Bell DD-587",
-                "shortLabel": "USS Bell DD-587",
-                "range": "",
-                "filename": ""
-            },
-            "USS Cassin Young": {
-                "name": "USS Cassin Young",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Cassin Young",
-                "shortLabel": "USS Cassin Young",
-                "range": "",
-                "filename": ""
-            },
-            "USS Cotten DD-669": {
-                "name": "USS Cotten DD-669",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Cotten DD-669",
-                "shortLabel": "USS Cotten",
-                "range": "",
-                "filename": ""
-            },
-            "USS Enterprise": {
-                "name": "USS Enterprise",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "CV-6 USS Enterprise",
-                "shortLabel": "USS Enterprise",
-                "range": "",
-                "filename": ""
-            },
-            "USS Fletcher": {
-                "name": "USS Fletcher",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Fletcher",
-                "shortLabel": "USS Fletcher",
-                "range": "",
-                "filename": ""
-            },
-            "USS Franklin -Big Ben-": {
-                "name": "USS Franklin -Big Ben-",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "USS Franklin -Big Ben-",
-                "shortLabel": "USS Franklin",
-                "range": "",
-                "filename": ""
-            },
-            "USS Gregory DD-802": {
-                "name": "USS Gregory DD-802",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Gregory DD-802",
-                "shortLabel": "USS Gregory",
-                "range": "",
-                "filename": ""
-            },
-            "USS Hopewell DD-681": {
-                "name": "USS Hopewell DD-681",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Hopewell DD-681",
-                "shortLabel": "USS Hopewell",
-                "range": "",
-                "filename": ""
-            },
-            "USS Hornet (CV-8)": {
-                "name": "USS Hornet (CV-8)",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "USS Hornet (CV-8)",
-                "shortLabel": "USS Hornet (CV-8)",
-                "range": "",
-                "filename": ""
-            },
-            "USS Illinois BB-65": {
-                "name": "USS Illinois BB-65",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS Illinois BB-65",
-                "shortLabel": "USS Illinois",
-                "range": "",
-                "filename": ""
-            },
-            "USS Iowa": {
-                "name": "USS Iowa",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS Iowa",
-                "shortLabel": "USS Iowa",
-                "range": "",
-                "filename": ""
-            },
-            "USS Johnson DD-557": {
-                "name": "USS Johnson DD-557",
-                "coalition": "",
-                "type": "Destoryer",
-                "era": "WW2",
-                "label": "USS Johnson DD-557",
-                "shortLabel": "USS Johnson",
-                "range": "",
-                "filename": ""
-            },
-            "USS Kentucky BB-66": {
-                "name": "USS Kentucky BB-66",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS Kentucky BB-66",
-                "shortLabel": "USS Kentucky",
-                "range": "",
-                "filename": ""
-            },
-            "USS La Vallette DD-448": {
-                "name": "USS La Vallette DD-448",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS La Vallette DD-448",
-                "shortLabel": "USS La Vallette",
-                "range": "",
-                "filename": ""
-            },
-            "USS Missouri": {
-                "name": "USS Missouri",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS Missouri",
-                "shortLabel": "USS Missouri",
-                "range": "",
-                "filename": ""
-            },
-            "USS New Jersey": {
-                "name": "USS New Jersey",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS New Jersey",
-                "shortLabel": "USS New Jersey",
-                "range": "",
-                "filename": ""
-            },
-            "USS Radford DD-446": {
-                "name": "USS Radford DD-446",
-                "coalition": "",
-                "type": "Destroyer",
-                "era": "WW2",
-                "label": "USS Radford DD-446",
-                "shortLabel": "USS Radford",
-                "range": "",
-                "filename": ""
-            },
-            "USS Samuel Chase": {
-                "name": "USS Samuel Chase",
-                "coalition": "",
-                "type": "Transport",
-                "era": "WW2",
-                "label": "USS Samuel Chase",
-                "shortLabel": "USS Samuel Chase",
-                "range": "",
-                "filename": ""
-            },
-            "USS Winsconsin": {
-                "name": "Winsconsin",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "USS Winsconsin",
-                "shortLabel": "USS Winsconsin",
-                "range": "",
-                "filename": ""
-            },
-            "WW II USS Intrepid CV-11": {
-                "name": "WW II USS Intrepid CV-11",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "WW II USS Intrepid CV-11",
-                "shortLabel": "USS Intrepid",
-                "range": "",
-                "filename": ""
-            },
-            "WWII Japanese Battleship Musashi": {
-                "name": "WWII Japanese Battleship Musashi",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "WWII Japanese Battleship Musashi",
-                "shortLabel": "Battleship Musashi",
-                "range": "",
-                "filename": ""
-            },
-            "WWII Japanese Battleship Yamato": {
-                "name": "WWII Japanese Battleship Yamato",
-                "coalition": "",
-                "type": "Battleship",
-                "era": "WW2",
-                "label": "WWII Japanese Battleship Yamato",
-                "shortLabel": "Battleship Yamato",
-                "range": "",
-                "filename": ""
-            },
-            "WWII USS Yorktown CV-5": {
-                "name": "WWII USS Yorktown CV-5",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "WWII USS Yorktown CV-5",
-                "shortLabel": "USS Yorktown",
-                "range": "",
-                "filename": ""
-            },
-            "WWII USS Hornet CV-8": {
-                "name": "WWII USS Hornet CV-8",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "WWII USS Hornet CV-8",
-                "shortLabel": "USS Hornet",
-                "range": "",
-                "filename": ""
-            },
-            "ZUIKAKU": {
-                "name": "ZUIKAKU",
-                "coalition": "",
-                "type": "Aircraft Carrier",
-                "era": "WW2",
-                "label": "ZUIKAKU",
-                "shortLabel": "ZUIKAKU",
                 "range": "",
                 "filename": ""
             },

--- a/client/src/units/unitdatabase.ts
+++ b/client/src/units/unitdatabase.ts
@@ -41,13 +41,9 @@ export class UnitDatabase {
     getEras() {
         var eras: string[] = [];
         for (let unit in this.blueprints) {
-            var unitEras = this.blueprints[unit].era;
-            if (unitEras) {
-                for (let era of unitEras) {
-                    if (era !== "" && !eras.includes(era))
-                        eras.push(era);
-                }
-            }
+            var era = this.blueprints[unit].era;
+            if (era && era !== "" && !eras.includes(era))
+                eras.push(era);
         }
         return eras;
     }


### PR DESCRIPTION
Added coalition to almost all units.

NATO and most of the Western world is: "Blue"
Warsaw Pact and most of the Eastern world is: "Red"

WW2 units don't have a coalition, this might be changed in the future.

Countries that are neutral also have empty coalition values