### PR TITLE
Fix issue #374

### DIFF
--- a/client/src/map/map.ts
+++ b/client/src/map/map.ts
@@ -584,7 +584,7 @@ export class Map extends L.Map {
                 else 
                     getInfoPopup().setText(`Selected units can not perform point actions.`);
             }
-            else {
+            else if(selectedUnitTypes.length > 1) {
                 getInfoPopup().setText(`Multiple unit types selected, no common actions available.`);
             }
 


### PR DESCRIPTION
Checked if there was more than one unit type selected before displaying the multiple unit types selected warning message.

No warning message displayed if right click with no units selected. 