### PR TITLE
Update and rename COPYING to LEGAL

### DIFF
--- a/LEGAL
+++ b/LEGAL
@@ -1,4 +1,33 @@
-                    GNU GENERAL PUBLIC LICENSE
+DCS Olympus
+
+A real-time AI unit control mod for DCS World
+
+Copyright (C) 2023 Veltro & Gang
+
+DCS Olympus (the "MATERIAL" or "Software") is provided completely free 
+to users subject to the it under both the terms of version 3 of the GNU 
+General Public License as published by the Free Software Foundation, and 
+the additional terms set out below; except where such terms conflict with this 
+disclaimer, in which case, the terms of this disclaimer shall prevail. 
+
+The authors and/or copyright holders of the Software have not received any 
+financial benefit in connection with the Software. In any event, the 
+Software is provided “as is”, without warranty of any kind, express or 
+implied, including but not limited to the warranties of merchantability, 
+fitness for a particular purpose and non-infringement. In no event shall 
+the authors and/or copyright holders be liable for any claim, damages or 
+other liability, whether in an action of contract, tort or otherwise, 
+arising from, out of or in connection with the Software or the use or o
+ther dealings in the Software. 
+
+Any party making use of the Software in any manner agrees to be 
+bound by the terms set out in this disclaimer, version 3 of the GNU 
+General Public Licence, and the Additional Terms below. 
+
+THIS MATERIAL IS NOT MADE OR SUPPORTED BY EAGLE DYNAMICS SA.
+
+
+                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
@@ -618,57 +647,14 @@ an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
-                     END OF TERMS AND CONDITIONS
+              END OF GNU GENERAL PUBLIC LICENCE
 
-            How to Apply These Terms to Your New Programs
+                ADDITIONAL TERMS & CONDITIONS
 
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
+1. Governing Law
 
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+  Save where specifically provided for otherwise, the provisions of the 
+GNU General Public Licence Version 3 above shall be governed by and 
+interpreted in accordance with English Law and the parties submit to the 
+exclusive jurisdiction of the English Courts.
+           


### PR DESCRIPTION
Cleaned up the legal text, added governing law, changed introduction

@veltro use the bit above GNU General Public Licence for the legal text splash on the login page 