### PR TITLE
Example script to set airbase to a certain coalition

### DIFF
--- a/scripts/examples/setcoaltionScript.lua
+++ b/scripts/examples/setcoaltionScript.lua
@@ -1,0 +1,24 @@
+function disableAutoCapture(airbaseName)
+    trigger.action.outText("Olympus.disableAutoCapture " .. airbaseName, 2)
+    local airbase = Airbase.getByName(airbaseName)
+    if airbase then
+        airbase:autoCapture(false)
+        trigger.action.outText("Olympus.disableAutoCapture " .. airbaseName .. " completed successfully", 2)
+    else
+        trigger.action.outText("Olympus.disableAutoCapture failed", 2)
+    end
+end
+
+function setAirbaseCoalition(airbaseName, coalitionColor)
+    trigger.action.outText("Olympus.setAirbaseCoalition trying to set " .. airbaseName .. " to " .. coalitionColor, 2)
+    local airbase = Airbase.getByName(airbaseName)
+    if airbase then
+        disableAutoCapture(airbaseName)
+        airbase:setCoalition(coalition.side[coalitionColor])
+        trigger.action.outText("Olympus.setAirbaseCoalition " .. airbaseName .. " set to " .. coalitionColor .. " completed successfully", 5)
+    else
+        trigger.action.outText("Olympus.setAirbaseCoalition Airbase not found: " .. airbaseName, 5)
+    end
+end
+
+setAirbaseCoalition("Khasab", "RED")


### PR DESCRIPTION
Two functions that disables autoCapture for a given airbase and changes to coalition to the wanted one.

This here is a example script that works. You'd just need to replace the trigger.action.outText() with Olympus.debug() and add Olympus. before the function.
