### PR TITLE
Basic Docker image for client app

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:20-alpine AS appbuild
+
+WORKDIR /usr/src/app
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install
+COPY . .
+RUN npm run build-release-linux
+
+FROM node:20-alpine
+WORKDIR /usr/src/app
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install --omit=dev
+COPY . .
+COPY --from=appbuild /usr/src/app/public ./public
+EXPOSE 3000
+CMD npm start

--- a/client/copy.sh
+++ b/client/copy.sh
@@ -1,0 +1,4 @@
+cp ./node_modules/leaflet/dist/leaflet.css ./public/stylesheets/leaflet/leaflet.css 
+cp ./node_modules/leaflet-gesture-handling/dist/leaflet-gesture-handling.css ./public/stylesheets/leaflet/leaflet-gesture-handling.css
+cp ./node_modules/leaflet.nauticscale/dist/leaflet.nauticscale.js ./public/javascripts/leaflet.nauticscale.js
+cp ./node_modules/leaflet-path-drag/dist/L.Path.Drag.js ./public/javascripts/L.Path.Drag.js

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "browserify .\\src\\index.ts --debug -o .\\public\\javascripts\\bundle.js -t [ babelify --global true --presets [ @babel/preset-env ] --extensions '.js'] -p [ tsify --noImplicitAny ] && copy.bat",
     "build-release": "browserify .\\src\\index.ts -o .\\public\\javascripts\\bundle.js -t [ babelify --global true --presets [ @babel/preset-env ] --extensions '.js'] -p [ tsify --noImplicitAny ] && copy.bat",
+    "build-release-linux": "browserify ./src/index.ts -o ./public/javascripts/bundle.js -t [ babelify --global true --presets [ @babel/preset-env ] --extensions '.js'] -p [ tsify --noImplicitAny ] && ./copy.sh",
     "emit-declarations": "tsc --project tsconfig.json --declaration --emitDeclarationOnly --outfile ./@types/olympus/index.d.ts",
     "copy": "copy.bat",
     "start": "node ./bin/www",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  client:
+    build: client
+    ports:
+      - 3000:3000
+    volumes:
+      - ./olympus.json:/usr/src/olympus.json


### PR DESCRIPTION
1. Build image with `docker compose build`
1. Run image with `docker compose up` 

Run client app separate from DCS server as Docker container

Assumes the `olympus.json` is mounted at `..` i.e. `/usr/src/olympus.json`, done automatically when using the provided `docker-compose.yml`

Tested with Linux WSL2 on Windows and Linux kubernets cluster

Requires #731