### PR TITLE
ci: Deploy directly to GitHub Pages without gh-pages branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   build_docs:
     runs-on: windows-latest
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
@@ -37,7 +40,14 @@ jobs:
         run: doxygen docs
         working-directory: ./src
         
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: docs 
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Uses new GitHub Pages actions to directly upload new content.

Needs a change in repo settings for successful deployment:
<img width="1109" alt="Screenshot 2023-12-28 at 00 02 29" src="https://github.com/Pax1601/DCSOlympus/assets/288631/02a9c3dd-a02c-4813-b0ab-90d4df56889c">

After this the `gh-pages` branch can be removed