### PR TITLE
Bugfix/v1/wrong unit on reconnection

### DIFF
--- a/backend/core/include/unit.h
+++ b/backend/core/include/unit.h
@@ -19,12 +19,12 @@ public:
 	~Unit();
 
 	/********** Methods **********/
-	void initialize(json::value json);
+	virtual void initialize(json::value json) final;
 	virtual void setDefaults(bool force = false);
 
 	void runAILoop();
 
-	void update(json::value json, double dt);
+	virtual void update(json::value json, double dt) final;
 	void refreshLeaderData(unsigned long long time);
 
 	unsigned int getID() { return ID; }

--- a/backend/core/src/unit.cpp
+++ b/backend/core/src/unit.cpp
@@ -57,6 +57,21 @@ void Unit::initialize(json::value json)
 
 void Unit::update(json::value json, double dt)
 {
+	if (json.has_string_field(L"name"))
+		setName(to_string(json[L"name"]));
+
+	if (json.has_string_field(L"unitName"))
+		setUnitName(to_string(json[L"unitName"]));
+
+	if (json.has_string_field(L"groupName"))
+		setGroupName(to_string(json[L"groupName"]));
+
+	if (json.has_string_field(L"callsign"))
+		setCallsign(to_string(json[L"callsign"]));
+
+	if (json.has_number_field(L"coalitionID"))
+		setCoalition(json[L"coalitionID"].as_number().to_int32());
+
 	if (json.has_object_field(L"position"))
 	{
 		setPosition({

--- a/backend/core/src/unit.cpp
+++ b/backend/core/src/unit.cpp
@@ -28,28 +28,6 @@ Unit::~Unit()
 
 void Unit::initialize(json::value json)
 {
-	if (json.has_string_field(L"name"))
-		setName(to_string(json[L"name"]));
-
-	if (json.has_string_field(L"unitName"))
-		setUnitName(to_string(json[L"unitName"]));
-
-	if (json.has_string_field(L"groupName"))
-		setGroupName(to_string(json[L"groupName"]));
-
-	if (json.has_string_field(L"callsign"))
-		setCallsign(to_string(json[L"callsign"]));
-
-	if (json.has_number_field(L"coalitionID"))
-		setCoalition(json[L"coalitionID"].as_number().to_int32());
-
-	//if (json.has_number_field(L"Country"))
-	//	setCountry(json[L"Country"].as_number().to_int32());
-
-	/* All units which contain the name "Olympus" are automatically under AI control */
-	if (getUnitName().find("Olympus") != string::npos)
-		setControlled(true);
-
 	update(json, 0);
 	setDefaults();
 }
@@ -71,6 +49,12 @@ void Unit::update(json::value json, double dt)
 
 	if (json.has_number_field(L"coalitionID"))
 		setCoalition(json[L"coalitionID"].as_number().to_int32());
+	//if (json.has_number_field(L"Country"))
+	//	setCountry(json[L"Country"].as_number().to_int32());
+	
+	/* All units which contain the name "Olympus" are automatically under AI control */
+	if (getUnitName().find("Olympus") != string::npos)
+		setControlled(true);
 
 	if (json.has_object_field(L"position"))
 	{


### PR DESCRIPTION
I'm not a master of C++, but the "final" thing should make the class safer and avoid unwanted overrides. Moved unit data set code from initialize to update since update is already called inside initialize to avoid code duplication.