### PR TITLE
Feature/v1/selected unit coords

### DIFF
--- a/frontend/server/public/stylesheets/panels/mouseinfo.css
+++ b/frontend/server/public/stylesheets/panels/mouseinfo.css
@@ -115,6 +115,7 @@
 }
 
 #unit-coordinates[data-location-system] [data-location-system] {
+	cursor:pointer;
 	display:none;
 }
 

--- a/frontend/server/public/stylesheets/panels/mouseinfo.css
+++ b/frontend/server/public/stylesheets/panels/mouseinfo.css
@@ -124,6 +124,53 @@
 	display:flex;
 }
 
-#unit-coordinates-title {
+#unit-coordinates-container {
+	box-sizing: border-box;
+	background-color: var(--background-steel);
+	border-radius: var(--border-radius-sm);
+	box-shadow: 0px 2px 5px #000A;
+	padding: 10px;
+	position: absolute;
+    top: -48px;
+	right: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0px;
+	transition: all 200ms ease-in-out;
+}
+
+#unit-coordinates-container[data-open="true"] {
+	gap: 4px;
+	top: -140px;
+}
+
+#unit-coordinates-container > #unit-coordinates {
+	width: 170px;
+	height: 0;
+	padding: 0 6px;
+	overflow: hidden;
+	flex-grow: 1;
+	transition: all 200ms ease-in-out;
+}
+
+#unit-coordinates-container[data-open="true"] > #unit-coordinates {
+	height: 90px;
+	padding: 6px;
+}
+
+#unit-coordinates-container > #unit-coordinates-toggle {
 	font-size: 10px;
+	flex-shrink: 1;
+	cursor: pointer;
+}
+
+#unit-coordinates-container > #unit-coordinates-toggle> #unit-coordinates-toggle-icon::after {
+	margin-top: 8px;
+	font-size: 12px;
+	content: "↑";
+}
+
+#unit-coordinates-container[data-open="true"] > #unit-coordinates-toggle > #unit-coordinates-toggle-icon::after {
+	content: "↓";
 }

--- a/frontend/server/public/stylesheets/panels/mouseinfo.css
+++ b/frontend/server/public/stylesheets/panels/mouseinfo.css
@@ -104,6 +104,7 @@
 }
 
 #coordinates-tool[data-location-system="LatLng"] [data-location-system="LatLng"],
+#coordinates-tool[data-location-system="LatLngDec"] [data-location-system="LatLngDec"],
 #coordinates-tool[data-location-system="MGRS"] [data-location-system="MGRS"],
 #coordinates-tool[data-location-system="UTM"] [data-location-system="UTM"] {
 	display:flex;
@@ -120,6 +121,7 @@
 }
 
 #unit-coordinates[data-location-system="LatLng"] [data-location-system="LatLng"],
+#unit-coordinates[data-location-system="LatLngDec"] [data-location-system="LatLngDec"],
 #unit-coordinates[data-location-system="MGRS"] [data-location-system="MGRS"],
 #unit-coordinates[data-location-system="UTM"] [data-location-system="UTM"] {
 	display:flex;

--- a/frontend/server/public/stylesheets/panels/mouseinfo.css
+++ b/frontend/server/public/stylesheets/panels/mouseinfo.css
@@ -108,3 +108,22 @@
 #coordinates-tool[data-location-system="UTM"] [data-location-system="UTM"] {
 	display:flex;
 }
+
+/*  Unit Coordinates  */
+#unit-coordinates .elevation::after {
+	content: attr(data-value)
+}
+
+#unit-coordinates[data-location-system] [data-location-system] {
+	display:none;
+}
+
+#unit-coordinates[data-location-system="LatLng"] [data-location-system="LatLng"],
+#unit-coordinates[data-location-system="MGRS"] [data-location-system="MGRS"],
+#unit-coordinates[data-location-system="UTM"] [data-location-system="UTM"] {
+	display:flex;
+}
+
+#unit-coordinates-title {
+	font-size: 10px;
+}

--- a/frontend/server/views/panels/mouseinfo.ejs
+++ b/frontend/server/views/panels/mouseinfo.ejs
@@ -88,11 +88,9 @@
                 <div id="unit-position-utm-easting" class="coordinates copyable" data-location-system="UTM"></div>
             </div>
     
-            <div>
-                <div class="mouse-tool-item">
-                    <div id="ref-unit-position-elevation" data-label="H"></div>
-                    <div id="unit-position-elevation" class="elevation copyable" data-value="---"></div>
-                </div>
+            <div class="mouse-tool-item">
+                <div id="ref-unit-position-elevation" data-label="H"></div>
+                <div id="unit-position-elevation" class="elevation copyable" data-value="---"></div>
             </div>
         </div>
 

--- a/frontend/server/views/panels/mouseinfo.ejs
+++ b/frontend/server/views/panels/mouseinfo.ejs
@@ -60,4 +60,41 @@
         </div>
     </div>
 
+    <span id="unit-coordinates-title" class="hide">Selected Unit Coordinates:</span>
+
+    <div id="unit-coordinates" class="mouse-tool" data-location-system="LatLng">
+
+        <div class="mouse-tool-item" data-location-system="MGRS">
+            <div id="ref-unit-position-mgrs"></div>
+            <div id="unit-position-mgrs" class="coordinates"></div>
+        </div>
+
+        <div class="mouse-tool-item" data-location-system="LatLng">
+            <div id="ref-unit-position-latitude" data-location-system="LatLng"></div>
+            <div id="unit-position-latitude" class="coordinates" data-location-system="LatLng"></div>
+        </div>
+
+        <div class="mouse-tool-item" data-location-system="LatLng">
+            <div id="ref-unit-position-longitude" data-location-system="LatLng"></div>
+            <div id="unit-position-longitude" class="coordinates" data-location-system="LatLng"></div>
+        </div>
+
+        <div class="mouse-tool-item" data-location-system="UTM">
+            <div id="ref-unit-position-utm-northing" data-location-system="UTM"></div>
+            <div id="unit-position-utm-northing" class="coordinates" data-location-system="UTM"></div>
+        </div>
+
+        <div class="mouse-tool-item" data-location-system="UTM">
+            <div id="ref-unit-position-utm-easting" data-location-system="UTM"></div>
+            <div id="unit-position-utm-easting" class="coordinates" data-location-system="UTM"></div>
+        </div>
+
+        <div>
+            <div class="mouse-tool-item">
+                <div id="ref-unit-position-elevation" data-label="H"></div>
+                <div id="unit-position-elevation" class="elevation" data-value="---"></div>
+            </div>
+        </div>
+    </div>
+
 </div>

--- a/frontend/server/views/panels/mouseinfo.ejs
+++ b/frontend/server/views/panels/mouseinfo.ejs
@@ -42,6 +42,16 @@
             <div id="mouse-position-longitude" class="coordinates" data-location-system="LatLng"></div>
         </div>
 
+        <div class="mouse-tool-item" data-location-system="LatLngDec">
+            <div id="ref-mouse-position-latitude-dec" data-location-system="LatLngDec"></div>
+            <div id="mouse-position-latitude-dec" class="coordinates" data-location-system="LatLngDec"></div>
+        </div>
+
+        <div class="mouse-tool-item" data-location-system="LatLngDec">
+            <div id="ref-mouse-position-longitude-dec" data-location-system="LatLngDec"></div>
+            <div id="mouse-position-longitude-dec" class="coordinates" data-location-system="LatLngDec"></div>
+        </div>
+
         <div class="mouse-tool-item" data-location-system="UTM">
             <div id="ref-mouse-position-utm-northing" data-location-system="UTM"></div>
             <div id="mouse-position-utm-northing" class="coordinates" data-location-system="UTM"></div>
@@ -76,6 +86,16 @@
             <div class="mouse-tool-item" data-location-system="LatLng">
                 <div id="ref-unit-position-longitude" data-location-system="LatLng"></div>
                 <div id="unit-position-longitude" class="coordinates copyable" data-location-system="LatLng"></div>
+            </div>
+
+            <div class="mouse-tool-item" data-location-system="LatLngDec">
+                <div id="ref-unit-position-latitude-dec" data-location-system="LatLngDec"></div>
+                <div id="unit-position-latitude-dec" class="coordinates copyable" data-location-system="LatLngDec"></div>
+            </div>
+    
+            <div class="mouse-tool-item" data-location-system="LatLngDec">
+                <div id="ref-unit-position-longitude-dec" data-location-system="LatLngDec"></div>
+                <div id="unit-position-longitude-dec" class="coordinates copyable" data-location-system="LatLngDec"></div>
             </div>
     
             <div class="mouse-tool-item" data-location-system="UTM">

--- a/frontend/server/views/panels/mouseinfo.ejs
+++ b/frontend/server/views/panels/mouseinfo.ejs
@@ -60,40 +60,44 @@
         </div>
     </div>
 
-    <span id="unit-coordinates-title" class="hide">Selected Unit Coordinates:</span>
-
-    <div id="unit-coordinates" class="mouse-tool" data-location-system="LatLng">
-
-        <div class="mouse-tool-item" data-location-system="MGRS">
-            <div id="ref-unit-position-mgrs"></div>
-            <div id="unit-position-mgrs" class="coordinates"></div>
-        </div>
-
-        <div class="mouse-tool-item" data-location-system="LatLng">
-            <div id="ref-unit-position-latitude" data-location-system="LatLng"></div>
-            <div id="unit-position-latitude" class="coordinates" data-location-system="LatLng"></div>
-        </div>
-
-        <div class="mouse-tool-item" data-location-system="LatLng">
-            <div id="ref-unit-position-longitude" data-location-system="LatLng"></div>
-            <div id="unit-position-longitude" class="coordinates" data-location-system="LatLng"></div>
-        </div>
-
-        <div class="mouse-tool-item" data-location-system="UTM">
-            <div id="ref-unit-position-utm-northing" data-location-system="UTM"></div>
-            <div id="unit-position-utm-northing" class="coordinates" data-location-system="UTM"></div>
-        </div>
-
-        <div class="mouse-tool-item" data-location-system="UTM">
-            <div id="ref-unit-position-utm-easting" data-location-system="UTM"></div>
-            <div id="unit-position-utm-easting" class="coordinates" data-location-system="UTM"></div>
-        </div>
-
-        <div>
-            <div class="mouse-tool-item">
-                <div id="ref-unit-position-elevation" data-label="H"></div>
-                <div id="unit-position-elevation" class="elevation" data-value="---"></div>
+    <div id="unit-coordinates-container">
+        <div id="unit-coordinates" class="mouse-tool" data-location-system="LatLng">
+    
+            <div class="mouse-tool-item" data-location-system="MGRS">
+                <div id="ref-unit-position-mgrs"></div>
+                <div id="unit-position-mgrs" class="coordinates copyable"></div>
             </div>
+    
+            <div class="mouse-tool-item" data-location-system="LatLng">
+                <div id="ref-unit-position-latitude" data-location-system="LatLng"></div>
+                <div id="unit-position-latitude" class="coordinates copyable" data-location-system="LatLng"></div>
+            </div>
+    
+            <div class="mouse-tool-item" data-location-system="LatLng">
+                <div id="ref-unit-position-longitude" data-location-system="LatLng"></div>
+                <div id="unit-position-longitude" class="coordinates copyable" data-location-system="LatLng"></div>
+            </div>
+    
+            <div class="mouse-tool-item" data-location-system="UTM">
+                <div id="ref-unit-position-utm-northing" data-location-system="UTM"></div>
+                <div id="unit-position-utm-northing" class="coordinates copyable" data-location-system="UTM"></div>
+            </div>
+    
+            <div class="mouse-tool-item" data-location-system="UTM">
+                <div id="ref-unit-position-utm-easting" data-location-system="UTM"></div>
+                <div id="unit-position-utm-easting" class="coordinates copyable" data-location-system="UTM"></div>
+            </div>
+    
+            <div>
+                <div class="mouse-tool-item">
+                    <div id="ref-unit-position-elevation" data-label="H"></div>
+                    <div id="unit-position-elevation" class="elevation copyable" data-value="---"></div>
+                </div>
+            </div>
+        </div>
+
+        <div id="unit-coordinates-toggle" data-open="false">
+            Unit Coordinates <span id="unit-coordinates-toggle-icon"></span>
         </div>
     </div>
 

--- a/frontend/website/plugins/controltips/src/controltipsplugin.ts
+++ b/frontend/website/plugins/controltips/src/controltipsplugin.ts
@@ -204,6 +204,11 @@ export class ControlTipsPlugin implements OlympusPlugin {
                         "key": `Period`,
                         "action": "Increase precision",
                         "mouseoverSelector": `#coordinates-tool[data-location-system="MGRS"], #coordinates-tool[data-location-system="MGRS"] *`
+                    },
+                    {
+                        "key": `Mouse2`,
+                        "action": "Copy to clipboard",
+                        "mouseoverSelector": `#unit-coordinates-container > #unit-coordinates > .mouse-tool-item > .copyable`
                     }
                 ]
             },

--- a/frontend/website/plugins/controltips/src/controltipsplugin.ts
+++ b/frontend/website/plugins/controltips/src/controltipsplugin.ts
@@ -206,6 +206,11 @@ export class ControlTipsPlugin implements OlympusPlugin {
                         "mouseoverSelector": `#coordinates-tool[data-location-system="MGRS"], #coordinates-tool[data-location-system="MGRS"] *`
                     },
                     {
+                        "key": `Mouse1 or Z`,
+                        "action": "Change location system",
+                        "mouseoverSelector": "#unit-coordinates *"
+                    },
+                    {
                         "key": `Mouse2`,
                         "action": "Copy to clipboard",
                         "mouseoverSelector": `#unit-coordinates-container > #unit-coordinates > .mouse-tool-item > .copyable`

--- a/frontend/website/src/panels/mouseinfopanel.ts
+++ b/frontend/website/src/panels/mouseinfopanel.ts
@@ -110,7 +110,7 @@ export class MouseInfoPanel extends Panel {
         const copyableElements = document.getElementsByClassName('copyable');
 
         for (const element of copyableElements) {
-            element.addEventListener('click', (ev) => {
+            element.addEventListener('contextmenu', (ev) => {
                 if (!ev.target) return;
 
                 const el = ev.target as HTMLElement;

--- a/frontend/website/src/panels/mouseinfopanel.ts
+++ b/frontend/website/src/panels/mouseinfopanel.ts
@@ -116,6 +116,8 @@ export class MouseInfoPanel extends Panel {
     #listenForCopyableElements() {
         const copyableElements = document.getElementsByClassName('copyable');
 
+        // TODO: copy all the coordinates and elevation instead of copying only lat, lng or elevation.
+
         for (const element of copyableElements) {
             element.addEventListener('contextmenu', (ev) => {
                 if (!ev.target) return;
@@ -134,12 +136,14 @@ export class MouseInfoPanel extends Panel {
 
                 if (!text) return;
 
+                if(!navigator || !navigator.clipboard) return;
+
                 navigator.clipboard.writeText(text)
                     .then(() => {
-                        //console.log('Testo copiato negli appunti!');
+                        // Text copied to clipboard. TODO: add a toast or alert for this event.
                     })
                     .catch(err => {
-                        console.error('Errore nel copiare:', err);
+                        console.error('An error occurred while copying text to clipboard: ', err);
                     });
             });
         }

--- a/frontend/website/src/panels/mouseinfopanel.ts
+++ b/frontend/website/src/panels/mouseinfopanel.ts
@@ -186,8 +186,8 @@ export class MouseInfoPanel extends Panel {
             this.#drawCoordinates("ref-mouse-position-utm-northing", "mouse-position-utm-northing", "N"+utm.northing);
             this.#drawCoordinates("ref-mouse-position-utm-easting", "mouse-position-utm-easting", "E"+utm.easting);
         } else if (this.#getLocationSystem() === "LatLngDec") {
-            this.#drawCoordinates("ref-mouse-position-latitude-dec", "mouse-position-latitude-dec", decCoordsString.split(" ")[0]);
-            this.#drawCoordinates("ref-mouse-position-longitude-dec", "mouse-position-longitude-dec", decCoordsString.split(" ")[1]);
+            this.#drawCoordinates("ref-mouse-position-latitude-dec", "mouse-position-latitude-dec", decCoordsString.split(" ")[0] + "'");
+            this.#drawCoordinates("ref-mouse-position-longitude-dec", "mouse-position-longitude-dec", decCoordsString.split(" ")[1] + "'");
         }
         else {
             this.#drawCoordinates("ref-mouse-position-latitude", "mouse-position-latitude", coordString.split(" ")[0]);
@@ -208,8 +208,8 @@ export class MouseInfoPanel extends Panel {
                 this.#drawCoordinates("ref-unit-position-utm-northing", "unit-position-utm-northing", "N" + utm.northing);
                 this.#drawCoordinates("ref-unit-position-utm-easting", "unit-position-utm-easting", "E" + utm.easting);
             } else if (this.#getLocationSystem() === "LatLngDec") {
-                this.#drawCoordinates("ref-unit-position-latitude-dec", "unit-position-latitude-dec", decCoordsString.split(" ")[0]);
-                this.#drawCoordinates("ref-unit-position-longitude-dec", "unit-position-longitude-dec", decCoordsString.split(" ")[1]);
+                this.#drawCoordinates("ref-unit-position-latitude-dec", "unit-position-latitude-dec", decCoordsString.split(" ")[0] + "'");
+                this.#drawCoordinates("ref-unit-position-longitude-dec", "unit-position-longitude-dec", decCoordsString.split(" ")[1] + "'");
             } else {
                 this.#drawCoordinates("ref-unit-position-latitude", "unit-position-latitude", unitCoordString.split(" ")[0]);
                 this.#drawCoordinates("ref-unit-position-longitude", "unit-position-longitude", unitCoordString.split(" ")[1]);

--- a/frontend/website/src/panels/mouseinfopanel.ts
+++ b/frontend/website/src/panels/mouseinfopanel.ts
@@ -83,6 +83,12 @@ export class MouseInfoPanel extends Panel {
         /* Selected unit coordinates panel interaction */
         this.#unitCoordinatesElement = <HTMLElement>this.getElement().querySelector( '#unit-coordinates' );
 
+        this.#unitCoordinatesElement.addEventListener( "click", ( ev:MouseEvent ) => {
+            console.log('cliccato elemento unit coordinates');
+            
+            this.#changeLocationSystem();
+        });
+
         const unitCoordsToggleEl = <HTMLElement>this.getElement().querySelector('#unit-coordinates-toggle');
         const unitCoordsContainer = <HTMLElement>this.getElement().querySelector('#unit-coordinates-container');
         unitCoordsToggleEl.addEventListener("click", (ev: MouseEvent) => {
@@ -129,7 +135,7 @@ export class MouseInfoPanel extends Panel {
 
                 navigator.clipboard.writeText(text)
                     .then(() => {
-                        console.log('Testo copiato negli appunti!');
+                        //console.log('Testo copiato negli appunti!');
                     })
                     .catch(err => {
                         console.error('Errore nel copiare:', err);


### PR DESCRIPTION
- Added a new coordinates panel when a single unit is selected.
- The selected unit coordinates panel has a toggle that stays in the last position set
- The selected unit coordinates panel is clickable to allow cycling through location systems
- Added a new location system compatible with older western aircrafts (DD°MM.MMM)
- The unit coordinates and elevation are clickable via right-click
- The unit elevation is shown in FL for aircrafts, in feet for all other units
- Added tips for all actions supported by the selected unit coordinates panel