### PR TITLE
feat(map): unit coordinates are now copied entirely. Added info poup.

### DIFF
--- a/frontend/server/views/panels/mouseinfo.ejs
+++ b/frontend/server/views/panels/mouseinfo.ejs
@@ -75,7 +75,7 @@
     
             <div class="mouse-tool-item" data-location-system="MGRS">
                 <div id="ref-unit-position-mgrs"></div>
-                <div id="unit-position-mgrs" class="coordinates copyable"></div>
+                <div id="unit-position-mgrs" class="coordinates copyable" data-location-system="MGRS"></div>
             </div>
     
             <div class="mouse-tool-item" data-location-system="LatLng">


### PR DESCRIPTION
Changelog:
* when right clicking the selected unit coordinates panel, all coordinates and elevation are copied to the clipboard
* when the copy is successful, a popup is shown to the user

Known issue: when Olympus is not running in a secure https context, the copy will not work. There's no workaround to this.